### PR TITLE
Release T1.1.10.2

### DIFF
--- a/nodesSetup.json
+++ b/nodesSetup.json
@@ -1,5 +1,5 @@
 {
-  "startTime": 1607418000,
+  "startTime": 1607634000,
   "roundDuration": 6000,
   "consensusGroupSize": 21,
   "minNodesPerShard": 82,


### PR DESCRIPTION
- release T1.1.10.2

for reviewers: please compare with `tags/T1.1.10.1` (only the timestamp should be modified)