### PR TITLE
Release T1.1.26.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,13 +12,13 @@
    StartInEpochEnabled = true
 
    # SCDeployEnableEpoch represents the epoch when the deployment of smart contracts will be enabled
-   SCDeployEnableEpoch = 4
+   SCDeployEnableEpoch = 1
 
    # BuiltInFunctionsEnableEpoch represents the epoch when the built in functions will be enabled
-   BuiltInFunctionsEnableEpoch = 4
+   BuiltInFunctionsEnableEpoch = 1
 
    # RelayedTransactionsEnableEpoch represents the epoch when the relayed transactions will be enabled
-   RelayedTransactionsEnableEpoch = 4
+   RelayedTransactionsEnableEpoch = 1
 
    # PenalizedTooMuchGasEnableEpoch represents the epoch when the penalization for using too much gas will be enabled
    PenalizedTooMuchGasEnableEpoch = 0
@@ -38,13 +38,13 @@
    TransactionSignedWithTxHashEnableEpoch = 1000000
 
    # MetaProtectionEnableEpoch represents the epoch when the transactions to the metachain are checked to have enough gas
-   MetaProtectionEnableEpoch = 4
+   MetaProtectionEnableEpoch = 1
 
    # AheadOfTimeGasUsageEnableEpoch represents the epoch when the cost of smart contract prepare changes from compiler per byte to ahead of time prepare per byte
-   AheadOfTimeGasUsageEnableEpoch = 4
+   AheadOfTimeGasUsageEnableEpoch = 1
 
    # GasPriceModifierEnableEpoch represents the epoch when the gas price modifier in fee computation is enabled
-   GasPriceModifierEnableEpoch = 4
+   GasPriceModifierEnableEpoch = 1
 
    # TO BE CHANGED IN MAINNET AND PUBLIC TESTNET CONFIGS
    # MaxNodesChangeEnableEpoch holds configuration for changing the maximum number of nodes and the enabling epoch
@@ -72,7 +72,7 @@
 [GasSchedule]
     GasScheduleByEpochs = [
         { StartEpoch = 0, FileName = "gasScheduleV1.toml" },
-        { StartEpoch = 4, FileName = "gasScheduleV2.toml" },
+        { StartEpoch = 1, FileName = "gasScheduleV2.toml" },
     ]
 
 [StoragePruning]

--- a/genesis.json
+++ b/genesis.json
@@ -31,8 +31,8 @@
   },
   {
     "address": "erd1lt0zj3783zztc6l7l8kr73levq6phj5da3ldmd5j3j3jua9r300q76d9d5",
-    "supply": "15000000000000000000000",
-    "balance": "0",
+    "supply": "115000000000000000000000",
+    "balance": "100000000000000000000000",
     "stakingvalue": "15000000000000000000000",
     "delegation": {
       "address": "",
@@ -151,8 +151,8 @@
   },
   {
     "address": "erd1qe5vcuetvla74llzs3dhl2ddv57skxumeva68ssz3ec93kgn5n3q3fer7g",
-    "supply": "12500000000000000000000",
-    "balance": "0",
+    "supply": "112500000000000000000000",
+    "balance": "100000000000000000000000",
     "stakingvalue": "12500000000000000000000",
     "delegation": {
       "address": "",
@@ -201,8 +201,8 @@
   },
   {
     "address": "erd19rh30cq9964an8vj7qnj7gwaus90nv6020vxpu69ramwrn8yr78smteycl",
-    "supply": "7500000000000000000000",
-    "balance": "0",
+    "supply": "107500000000000000000000",
+    "balance": "100000000000000000000000",
     "stakingvalue": "7500000000000000000000",
     "delegation": {
       "address": "",
@@ -271,8 +271,8 @@
   },
   {
     "address": "erd1jcvlfkmtvmjnw96um4y6rmmj8fseuk9zu7ywwjhq4cqjrwrfqcvszs4nqm",
-    "supply": "15000000000000000000000",
-    "balance": "0",
+    "supply": "115000000000000000000000",
+    "balance": "100000000000000000000000",
     "stakingvalue": "15000000000000000000000",
     "delegation": {
       "address": "",
@@ -421,8 +421,8 @@
   },
   {
     "address": "erd1xkmduha0sn4k3yx9fsapavlxrnh2e4fxm8qlafgdgmy6pg4y4zkqav9tdk",
-    "supply": "5000000000000000000000",
-    "balance": "0",
+    "supply": "205000000000000000000000",
+    "balance": "200000000000000000000000",
     "stakingvalue": "5000000000000000000000",
     "delegation": {
       "address": "",
@@ -701,8 +701,8 @@
   },
   {
     "address": "erd146zgxv6dv2x5d2cangu7r6flw8gv7ck2sjzf84l7lueh6h2lgg5s7ud0g8",
-    "supply": "10000000000000000000000",
-    "balance": "0",
+    "supply": "110000000000000000000000",
+    "balance": "100000000000000000000000",
     "stakingvalue": "10000000000000000000000",
     "delegation": {
       "address": "",
@@ -1170,9 +1170,19 @@
     }
   },
   {
+    "address": "erd1pwx89w2f6zgmjaqjveyp0v4fx32jgvx5l69r8gw27f50xqvgv5sqfmmq69",
+    "supply": "100000000000000000000000",
+    "balance": "100000000000000000000000",
+    "stakingvalue": "0",
+    "delegation": {
+      "address": "",
+      "value": "0"
+    }
+  },
+  {
     "address": "erd1932eft30w753xyvme8d49qejgkjc09n5e49w4mwdjtm0neld797su0dlxp",
-    "supply": "7288750000000000000000000",
-    "balance": "7288750000000000000000000",
+    "supply": "6888750000000000000000000",
+    "balance": "6888750000000000000000000",
     "stakingvalue": "0",
     "delegation": {
       "address": "",
@@ -1181,8 +1191,8 @@
   },
   {
     "address": "erd1sea63y47u569ns3x5mqjf4vnygn9whkk7p6ry4rfpqyd6rd5addqyd9lf2",
-    "supply": "7288750000000000000000000",
-    "balance": "7288750000000000000000000",
+    "supply": "6888750000000000000000000",
+    "balance": "6888750000000000000000000",
     "stakingvalue": "0",
     "delegation": {
       "address": "",
@@ -1190,7 +1200,7 @@
     }
   },
   {
-    "address": "erd1epuwnejn6rcnnxza2rwmy2xez7055xw023tzl0y9y7zc5388uq7sldqau3",
+    "address": "erd1argrwq4h5flnf7j6lyuy8c9zxtw8szxfm9mjm82vw7ex8n5pd75shj83r2",
     "supply": "3576120556414219475379",
     "balance": "0",
     "stakingvalue": "0",
@@ -1200,7 +1210,7 @@
     }
   },
   {
-    "address": "erd1gql53wa4mx389k56yj5sdxpznhe8hj9zpkfyn8dk8ht8j7jfughsyr3huj",
+    "address": "erd15x77tjhurpu50eg33cjurkduf93eu5waed7nc84ddqat8lu3ntlqcjk8hw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1210,7 +1220,7 @@
     }
   },
   {
-    "address": "erd1ad73wcgesgswu8evu3v6k57yu5pk4m3a04zeuq55y08n3fvpunfqzc9asq",
+    "address": "erd1a4u0yh0mzct03f27wz4wgh7hnkxfj03d6uwpl50nsfvpme9qse3qpkazn2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1220,7 +1230,7 @@
     }
   },
   {
-    "address": "erd1d0dmgfx6wjay296wfmh8rgpe2kyk5mfnm6qhuw8325x6mwhfcjcqzh5qxf",
+    "address": "erd1j0ap2rad2mm9gnankj3tu6uz40sahvq9d8ztjp95vhsxxs0mpnus26d4yg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1230,7 +1240,7 @@
     }
   },
   {
-    "address": "erd1egv89sxukdu93qhtjskczdq8zag9vnkkddny8nvk98nx2t4tvyaqtu2x9t",
+    "address": "erd1e53ght2x8g4dm5fvkztg74m76qklage24qgequ2rvwf7jwuxvguqcpq00j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1240,7 +1250,7 @@
     }
   },
   {
-    "address": "erd18emq40nk9fxw0cf8lskqnd63jfdrzmkwaaee8vwx5fed4rhner9qffruj0",
+    "address": "erd1kgm4eyaxr0gpp3sp52sle08x7mjr020jldfc7j8kaj8dxazww8qsx5wxhf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1250,7 +1260,7 @@
     }
   },
   {
-    "address": "erd1p3yld7zv698207g5ss2zyn4p9z9krxthz8xkn5ftnu0xyajmgqasn0zr3e",
+    "address": "erd1eqt346e4h07uh8s265u09cd9tkvj3dpdftcw9la6ht6jqh9u7v0s9cmmu0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1260,7 +1270,7 @@
     }
   },
   {
-    "address": "erd1yae37xhtvlwag2rql602lhwk37nszdpu0t5qczxuflleh3vw73tq2hvsky",
+    "address": "erd1sjmckz4zgfh98efhagwk9jshrz84gwg6c26ga5h2l8wlxm9huvfslwys0k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1270,7 +1280,7 @@
     }
   },
   {
-    "address": "erd1jdsase96yzcwp02cqsj3kkzrren3fhc5egukfjsr8t0tcnyazhwsldh57h",
+    "address": "erd1hlzvt92qfjs72mpr892lqzvj4tvcww6nqmlgyaysxt5jnmudh5gqkw8c3v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1280,7 +1290,7 @@
     }
   },
   {
-    "address": "erd1evwplfxmth9n8vrlzy7fg85jw2w54phmznhrmncpwm8q8d3w8s5qurk5hh",
+    "address": "erd1ye5gt5alplhtq2pmyyx0mr4zfr0mnljgunzlm4n6jv02pkd4ktgqj6k9t7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1290,7 +1300,7 @@
     }
   },
   {
-    "address": "erd13euuqpzt4x8tpduwchgyyndqp9mpgn9rafge7tneg2uzcc0fvhhqk3f5n2",
+    "address": "erd166umqh3ueymcusuvfkfv6jaqn5j4lrjs5ltqw3vk8wqj44ma04vqtv64lj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1300,7 +1310,7 @@
     }
   },
   {
-    "address": "erd1vzc0susd8gp6ktyfszumyqmkswh37e9ala3ye9fq7vzq8s0qdpsq9lucsk",
+    "address": "erd1hytaxh7j7z4heeq5hls4acr39plpalj60qwdhns4xjc0l2jxy47s8lwyvj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1310,7 +1320,7 @@
     }
   },
   {
-    "address": "erd1zeq9fpaad045uftja70sylgk3kgpxexlycqq2whge5hm3e43lveqlnedtw",
+    "address": "erd1l6f0p3hw6xzv8n6xykux0qpxth666v8f2hmupxhv5q7qwqzt4hvsvgajm0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1320,7 +1330,7 @@
     }
   },
   {
-    "address": "erd1pcfwy5z7r9zzamzfrpjfgunkl2u6rkdhpw4kqysjpqgth8wcuass6624t9",
+    "address": "erd1qy39ega3jr854lh4y8x524a2n6zdp6mgpqx25xmk9pd37xq3znfsune3fk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1330,7 +1340,7 @@
     }
   },
   {
-    "address": "erd1nfx5e9zpcgtpq6eraj4u4pw6emtzc29ewvdnav90au54faytantq0nrwp3",
+    "address": "erd1eh766h4a6plapcmy5y25my845k4ygmqe8q58el5w3s2ayjhux0xs9fzvpt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1340,7 +1350,7 @@
     }
   },
   {
-    "address": "erd19h8d8trs7rzgs9aemwkca8hytyhxfhdg4gn4ardsyzp6rlhte3gsv7vlnv",
+    "address": "erd15mjaf4kpgq04uw5nqa6g83jdaj0ltvunfypq3tnp4e0v93tl38zq5tg247",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1350,7 +1360,7 @@
     }
   },
   {
-    "address": "erd109cakv3uwc6ceetml9w0eqnkapv8jy0heav42enach0r7q8xtqtqggvwus",
+    "address": "erd1ws32uu9sdq9rnldqq7v7msultlwrrp9c4xsvplvvumuwy5m596rs3fp6lx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1360,7 +1370,7 @@
     }
   },
   {
-    "address": "erd1mraqdp4d94fewemel0qdzqm3m6yp7upuu76ctps0ym4krvnfellq3c3exu",
+    "address": "erd193qw6ygkshne3vce258rwflu0kewg6sn5rk5cyawxzrncjvzk33qtgcjn0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1370,7 +1380,7 @@
     }
   },
   {
-    "address": "erd1zpwltzc5c6vja9r27lh8nhxkztgyf8494as37h08mqqeczktgy7ss23vn3",
+    "address": "erd1fqa4kw9ayyg5l20rjazhwctwwdeqnkmshlghhkqn0y60ljrmw8vqqxxqwf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1380,7 +1390,7 @@
     }
   },
   {
-    "address": "erd1zh330zt8j38uduu8ls88wyhdcjmg7dxahhuphqvsvcd8xwx2mclsfkjyxt",
+    "address": "erd1gmt7xmftae6rhr4rvvptejfyjppqwvvk2sx2dwghch9w3pcrzyqq5mr96p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1390,7 +1400,7 @@
     }
   },
   {
-    "address": "erd1jtqez4yx3fdusduqkszcj39szaempngnwgy206ysyafnlezndlhsnjpvh8",
+    "address": "erd1prvsf7nq7yndrfykp3h3ff5urhc2pzyn02tt0wqzpgun5w27al6stwrrpz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1400,7 +1410,7 @@
     }
   },
   {
-    "address": "erd1nzrm3at62765f4ludxjms0g6czqyyhxysvdm6lf2d3hlakp04essg4ehnj",
+    "address": "erd1srzfe96m3g5gvlfrv0p6e5kj2phtjsdfxu5g5uddqdw8e5hhup6q8u4u5c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1410,7 +1420,7 @@
     }
   },
   {
-    "address": "erd1wdpx4mdxc69ffeuym8497ns2s2fe44yupa0yc893e0ds3q32ds5sv60sqp",
+    "address": "erd1v6s3k03phhnzmt3y4efz0qxxnqw9jqgwcdym0a5dvje22m0gg99sdf5xqr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1420,7 +1430,7 @@
     }
   },
   {
-    "address": "erd1sygtk3rpjjyw2el7stq2te2pq9gcdfr43uv3vdkcdfwylhgd2uzs4nwtlq",
+    "address": "erd1fdh3vpm69pdsv2xmyr4uhqqz5jg6q0v6sh8xk4mphhrds7drslysj7emzk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1430,7 +1440,7 @@
     }
   },
   {
-    "address": "erd1hqw796s5l56laavmys849x9h2tkqsrz5f2w2rmgk4z65z23gzu2svcmyrq",
+    "address": "erd1vr6s55jc8ffjfpjpyj3luapast2f53unye0x0u33ccedv032gs9sd60yen",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1440,7 +1450,7 @@
     }
   },
   {
-    "address": "erd1znn3c2uey7807vtrdsgk7s3f9x4cahvcvmfl98tjmjvpx46qd2as9h3t7y",
+    "address": "erd1rlnm7jha50xsjud88hm2u3zr56av523frysc34rq7f73lthcluwqe4j5cx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1450,7 +1460,7 @@
     }
   },
   {
-    "address": "erd1sfqvm5yjtfrrawy8f0h40zysx66vmwkhjrps2nprlckkezjtjpyqzsxk8t",
+    "address": "erd1hqmrt5h6zls0qr56w33d3hxayacg0uezvqvuxzzqf0a7q6uj86cs07twdc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1460,7 +1470,7 @@
     }
   },
   {
-    "address": "erd1h2mcgw5t825fmrwxru27dk4m87658my988rw97lf05s9d4r58gcq5528zw",
+    "address": "erd1dalgkzvk0zen9hq8l5qvlew50njlcdveh8ugxrs2cdy80urrfkzskzjmrw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1470,7 +1480,7 @@
     }
   },
   {
-    "address": "erd1097vxlk7rwqlucq9h2txfmrlqllgks9gndwj24upa82amnae3l3q34wfdm",
+    "address": "erd1dz2mcx84k42eqjpax8hq3406xn5j6m53fcm8d0xk5phja23eq8dq7tk0cl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1480,7 +1490,7 @@
     }
   },
   {
-    "address": "erd102pk49eaaqgewyz42m0jace503ryg9nq7c0ts0f7q3ec9f50y6lq4qxw5y",
+    "address": "erd1kufk799k7v2d4lvcuv7ykpdxdek7facxmtrj9nsvumr79j2t87rszazayw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1490,7 +1500,7 @@
     }
   },
   {
-    "address": "erd1stnt8r39uvxfee3uyptk2uj697rg5td854e984c8h5p3n7tscr3savuacg",
+    "address": "erd1w9gk6r8ta2jvgm5al8pr0tswl3xd9u9r6sxypy8gpq4psatd7q5q3dck5p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1500,7 +1510,7 @@
     }
   },
   {
-    "address": "erd1svjhdk4a02wknmz6zv97uuj7r5k4madh8t568fejk5qevaa3neaqe8m62e",
+    "address": "erd1d0rpkdmlnk9rtwzmtnryp4ktaljckannzjrz54tzn2ym6fgn3scsf5dp8m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1510,7 +1520,7 @@
     }
   },
   {
-    "address": "erd1lzrnq3vtqhxqaamfknwvfx34k0m6d7a9agskzvpymdkswj43arfqpn5mex",
+    "address": "erd154seqq37hfhlsj2dr8nych05h5cageqesy2namedy2uy9whhpawsjkxysp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1520,7 +1530,7 @@
     }
   },
   {
-    "address": "erd1p0ryvctk3tfflrn0em0l7vhcvwg0yd7gn0y30v9jqvdmlvm832nq6ta9e9",
+    "address": "erd1kv2x976nn6src2n6w4t5tdycq9q458d8qlqdq9zfwqhj4c8m985qglzzjg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1530,7 +1540,7 @@
     }
   },
   {
-    "address": "erd1pztkycujnhjrvd8dmjqcvt5xmaj8l6rl2gfdnjpnktcrxnmjwsashr0hkx",
+    "address": "erd1ctp9la3h80dzggg6p4dtggg0p3mdcplr6dwevtkf8uqar5fx2cys3xyxhc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1540,7 +1550,7 @@
     }
   },
   {
-    "address": "erd1jun6f9985v8auxv7wuef4hyp9n4up9pckk6px437kvv3w4kkv6ss4wsnvh",
+    "address": "erd1pty8xwuwe24jqa3w63m3hxdhp0wh2fx75hxpld893pknju8j7s2sw9veee",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1550,7 +1560,7 @@
     }
   },
   {
-    "address": "erd1jcstyqsre4304gedk9wlgk20l9vj9cjmlxlq38y5h8w0yg36d5mqmuk98c",
+    "address": "erd1m0x8apcwckap6l84rhymjqrex9mukvmwxje5f2hy73ku5wgddkdshfjfll",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1560,7 +1570,7 @@
     }
   },
   {
-    "address": "erd1f2hvzv59jd029s4xv83w0qu92fw83wn8mggtzlmqn4ncuy256xeq9eejvr",
+    "address": "erd1c3025ajrkc3v4eupatjl6ucncnapxlyhpauukyzqyhd7udj8jansrc3wj6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1570,7 +1580,7 @@
     }
   },
   {
-    "address": "erd1qwrm3xz5eufqhtc279rxd60hk2h522zkkwjewszuutdte27l25ls7lw5w8",
+    "address": "erd1jy42j6a2d09r5ysc7f5hwjz8zacfefha6gjwm3un3fafv0u26pgsk32495",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1580,7 +1590,7 @@
     }
   },
   {
-    "address": "erd1lh57ffg7pv67syfclznp0t089lx3ny02lnhj67hecxq34rwtlepsacj7h4",
+    "address": "erd1qx4csl456tat35fpw3hy8y562ll6jn72279292deal74su7d3jzs3uxhr0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1590,7 +1600,7 @@
     }
   },
   {
-    "address": "erd19ek7ktmrzcxeanlujq872g0rsyxujmmwnpxczn000pyer2yuvfwsppwn3n",
+    "address": "erd1s400n2n9kak0p9w6887nglhatt4cdr7rs2vlc909je2ax5p30wzs8qg44l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1600,7 +1610,7 @@
     }
   },
   {
-    "address": "erd1cpeqjlcsstpwjqr8kaa4lv8dl8ut3t770552m0wjvtjsc5re9xns95ur7g",
+    "address": "erd17crz2qyuw6jrnky3hgn4n3pjk9ak6lqz29exjj5zd2ec2qaw9jlqewnmk5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1610,7 +1620,7 @@
     }
   },
   {
-    "address": "erd1tuky0ku82t98x4fenhllatzncepv4fmc3j5vulhplnvdtt435stsx4s5ke",
+    "address": "erd1xzswyww95adg4gz03ck5sn0uj54kuk432nnvkmepzdrwdhtglrdqw3dv5g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1620,7 +1630,7 @@
     }
   },
   {
-    "address": "erd1qpvhe5tle7d5uaw2fvlad69phsgah00thhpsxn6ww6epflv92txsnguduh",
+    "address": "erd1xc6rq4pa8cnkp8flg4n5s5ny2wjmsqx3x78afrlx4xwkwrqzxzkqpcj7uf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1630,7 +1640,7 @@
     }
   },
   {
-    "address": "erd1rj3q8j5je53j37r9kfjlyj0seq400zu9jdht8ccwplyy2jpqq42szzrj9j",
+    "address": "erd10kjhfwpu7crkmaneyc708j8har543gw4hfqhaajua6kd4gfh0pasc6ucvd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1640,7 +1650,7 @@
     }
   },
   {
-    "address": "erd13tulggz2c0ddc48wqgce2u02nmmxj9x27vv3d69d96av5kwez3wq5j3pjx",
+    "address": "erd1ltynhwpxkz8g35kx34zptzeg3qxkyc5rt3n73s0afaamuv0f8suqq7rd9p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1650,7 +1660,7 @@
     }
   },
   {
-    "address": "erd1vzcxhl8wtjke4ntpd2msu3v9yfdv7glug7krk3k4t8pxtex68tcsej9smh",
+    "address": "erd1pjq6lp53m8aqlsffd5mq0dtmvwrygtf3vpd74jhf6p7pem58edds4cnzqa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1660,7 +1670,7 @@
     }
   },
   {
-    "address": "erd1kqfcxgvjgfarkqf9kukgapnt8685mhcln5qqf3cur8xsv3lwg40shuvqvg",
+    "address": "erd16vcx3599awkc3z53xjj6mt6xztdfgt2w8379w2s26xrrqvrkwm7s2qsals",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1670,7 +1680,7 @@
     }
   },
   {
-    "address": "erd1zenmdw6qd9n3nudpvhe9gcv8nud4gg2l3szulspyjwc6lfyr72jsq5knyq",
+    "address": "erd18796rfestg9natfxw4lyt7d3nsns035uk5gyg7snvufvuvdy4gysyt6ctu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1680,7 +1690,7 @@
     }
   },
   {
-    "address": "erd102zqwu96t5759sz04sdlwrkfmh6uc2rfu0wvms8836gqqs06hnys5akuwt",
+    "address": "erd10tkq4y45tld27f7z9sje8tldraauwfa2r94cnqufv7qdkntdsygqleeyxj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1690,7 +1700,7 @@
     }
   },
   {
-    "address": "erd1se8zq4l508jsn0l9rtwurxtk6d4h8xdtstvp7f7he9n3t59607jsntyl6f",
+    "address": "erd14wk9gk9hzdtpg9c9hcdzqchcej2trxl6qaqgwex0efw6fdshukpqq9vxn8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1700,7 +1710,7 @@
     }
   },
   {
-    "address": "erd16sve5872ec0339l3p8e7fd4r7sks0wetjrrp9k9nc8e5gxkpgygqm922r7",
+    "address": "erd18a78c0f56vsy9py0s724q2wj0s6tkxalyqhgyakzqgvd4lm0n92sgrhj23",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1710,7 +1720,7 @@
     }
   },
   {
-    "address": "erd1sggtzmed0rzdr0g6apt9l4q3ananzkp006my7d32wg04wuhzv7wstd9h8w",
+    "address": "erd10engfvmmxh5ytql78q2m33wam0q0uh7qu9ttprh2p9r78qjkgm7qgvu3fj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1720,7 +1730,7 @@
     }
   },
   {
-    "address": "erd1jvku8wk5z25kxpypuxvdy42l5ylsgk6k4q4rf9r34jgkardds98sntvas2",
+    "address": "erd1mwfleevjntrhfegng7sdr52uqp7mfnz52kuamznfvpuh0ffy0v4suczy2x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1730,7 +1740,7 @@
     }
   },
   {
-    "address": "erd14qgwyem8rmmy6ny3nsgpy0gpt55pkj4yn7shjmlgd3ccgpmtrgzqtu9e9x",
+    "address": "erd1cc0g942ymn4v2u6p6vgjgf3vkv48lmeaemus66ldshl6pv8c33qs7h2nrh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1740,7 +1750,7 @@
     }
   },
   {
-    "address": "erd1m2f9xqgswumwqkdn3wpvcq4a5e8efxrc949qf4gep7lh0ph5p7qqdaf0ey",
+    "address": "erd1gqeznt4ldsw3894trhmzwrfy2vqrymhp3aqfnqnmsmmkwalk0hjqru7s3f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1750,7 +1760,7 @@
     }
   },
   {
-    "address": "erd1s46nt53je0qldqm8pksf5ypszrene2tsgz09dkt7wlaj0xz35ppstlfs3z",
+    "address": "erd1dx559hdc7t9fphuhtndl4h9edpsktm9q6v78l6vvul2eya7u45vsu2mu4t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1760,7 +1770,7 @@
     }
   },
   {
-    "address": "erd1eldnc65zn3p0ypxggevm3skj9kccpts4tkumk0l6udwvg9nqvk2svc9reu",
+    "address": "erd1f0jpa7g0n2yd7vxjdw2emrup5atfs04snhkwj2zle5jzq5z8ttnsxpe0km",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1770,7 +1780,7 @@
     }
   },
   {
-    "address": "erd17m5hmven4tdh5cauu6ajlzzy594qw4xdh9mx5v52py43ter3stwsw73az8",
+    "address": "erd1jrd6l6wkn4fqmey0ek9qx27qvuyn2ncwgzz8dlt9kdrv6d2x9gdq7r5p2m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1780,7 +1790,7 @@
     }
   },
   {
-    "address": "erd1x8aekjq0z9wnarsq2qr3as5uertatrh25pevd324xqhk2e4x5hfqfhs6vn",
+    "address": "erd1hf0x8qs0gy9zlt96g5frd5q93zn8y75n4v9elkyphensqql07reqrhqcxq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1790,7 +1800,7 @@
     }
   },
   {
-    "address": "erd1f5a42aut7htxje0h7j8ha42v5zurdkp5vuwjgm3ryhuwhz59ucuqxvzs44",
+    "address": "erd1gu23x3ypl8ema0kd6u66wv6przjap72wfh6afptphl2ayefkwadqmu4wze",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1800,7 +1810,7 @@
     }
   },
   {
-    "address": "erd1xmps4vlakjfy5quvxuq5482z7xk220zcdh2upp2av839v55h0qrqneu2tw",
+    "address": "erd1ysj9hqy42gfj5acv860cd7dr5fd7kp2kmlmq89mqtl0xr5tjts2qxlzprv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1810,7 +1820,7 @@
     }
   },
   {
-    "address": "erd1y23nq3exl65s04sg3mxf9h5rl8330suv9yxpnyz3myrl8xgkm3ysx8rrc7",
+    "address": "erd1j6et0g34eeggll4xuqmpvmxxwr89xug9caseyrn7e0u87c4v0cmq3rqw4m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1820,7 +1830,7 @@
     }
   },
   {
-    "address": "erd1gv5whq09lunlnx50z989p9hmluud0xvda2psaw0q7hur64nvq65s8e66le",
+    "address": "erd1m7jze90k99u9jq34d05kkcdj4gx5zp0drysf678snnx2vcuqtmmsqf0ha5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1830,7 +1840,7 @@
     }
   },
   {
-    "address": "erd1tq32r5ctaadc9k53n0aq853d7vevq62vx5tgu3alrf2eexpjja3scgxz9t",
+    "address": "erd1608pudapykedqaj7al489wng9p0x8faxj0kllf459lrufwaja5gse4f8vl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1840,7 +1850,7 @@
     }
   },
   {
-    "address": "erd12zd20wgthh2cq4a2zxmjpte87jzcr5au9qg743quqw8r5x6lgduq2nk4w2",
+    "address": "erd1lthxe2lccnlsv87n2wcjnhmuwg8uqyvuqk3ykx6ezdxrk42ra49sal6hxp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1850,7 +1860,7 @@
     }
   },
   {
-    "address": "erd1vgjq3vpx4mdxpyw4wa787jn7eypjgre990mhrdz9dssuwypdpetq76uvgs",
+    "address": "erd13kn6pc80lz3ffyq43dq2vhzh6qeflhgwqpp08fd7zd5znxd3nwusuu9c3f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1860,7 +1870,7 @@
     }
   },
   {
-    "address": "erd1e7tal8m9htl793u2g0keynmkf4el8vxqh72m6y767nt0sxxvqessxqr44f",
+    "address": "erd12prmg2x2jn0v8qhdt0saeqgqyavqkk59fg3ugc4zlv6y0vgtkdrqc3tu6d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1870,7 +1880,7 @@
     }
   },
   {
-    "address": "erd15eqzmacyga3uu9ng0t4ptf99grkg2vswz0afvy8xeqsdm84qk20q52ep4w",
+    "address": "erd1fr3n8kqf4c5cgxe29h4r3mwen5g3v2l8uemwn0htd9jwm2h02x0sju0ceh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1880,7 +1890,7 @@
     }
   },
   {
-    "address": "erd1rhl92d9swfrqhdex8d0stsjfuczupq0gz7efjyxuzlna0w0gmeksh69nrn",
+    "address": "erd1nqn6p6d7x9cp0au7am4fc4y8uxc7my3yetnzvrgjt5z86qhy85jslfc82v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1890,7 +1900,7 @@
     }
   },
   {
-    "address": "erd1tp47anpjk9ydqpnfel39gg6w29yzvjdnapmtat9s24j69d83pjxqtchr8u",
+    "address": "erd1k7day732pahaqvtv5x7mv9l4avm5ztwwd3xkkfd2dwdqk7g3mwwqjhk8ux",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1900,7 +1910,7 @@
     }
   },
   {
-    "address": "erd1khydlhaya3xvxdwsyn3jne9wqqd7cgmzk4j9t28kwwejsf2v9pzs4tnh6g",
+    "address": "erd1pwu99mpmtp5ckpnh4hj7yvmnnvp6rykz3xflhskn8ncq4nenlhuqh4agwy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1910,7 +1920,7 @@
     }
   },
   {
-    "address": "erd1puh3z96hx969ftkslc05cdphv2w6l9sxryy4tq56uuecggqx29fsgwzdsv",
+    "address": "erd14cnck7402vr9zrcrc0z8cnzxdgmyyyxj62k7ts6d2g6zf7lltptsadj898",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1920,7 +1930,7 @@
     }
   },
   {
-    "address": "erd1p3h4fwr45cshszg3nj7y49j97julryp6c8n6mpwq54fcnuyvk5hq3ngm2g",
+    "address": "erd16ht6qw00s8f3nez4w5z2sl5vw0ay93pu0npd54ufyx3fvzzpm8hsf99tjw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1930,7 +1940,7 @@
     }
   },
   {
-    "address": "erd13kv6rdrjn5pcypv0xfarfydggqdkmmyaq23vye002vugy39kyacs34sueu",
+    "address": "erd1qlqh2vs720v09faa9rav8sj6nqwawv6qzjuvw0uygn503l4hegzq2f0cdt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1940,7 +1950,7 @@
     }
   },
   {
-    "address": "erd1fkstnd0l5yr37ly8puzxhxhjgz47gf7ftvzgchwqpvf0ncxjpuxqlmc70w",
+    "address": "erd1cv8kp47te7mprze6rja2dgy0rcqd0k2yq9z33pnpt5k4r98ru4mqmjj69c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1950,7 +1960,7 @@
     }
   },
   {
-    "address": "erd1ugj5t92fqr9ph7uneyqsevj6d9aavwzhkw4lkzk49sln67vfgcgs4znyaw",
+    "address": "erd1vr49fc27tqdcrnlvd4vnypha5wl3f8afynetyzm9eys8gv6uwk2qmy9z7d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1960,7 +1970,7 @@
     }
   },
   {
-    "address": "erd1ws0r7kzv0elldjj055nwvrta9tuecw59mxr6kgqwqj63ckur2nvqxzt2k9",
+    "address": "erd1yl8zxx2ng9ll09tr04a5xn73vjhqayscyzq8gatpkgmrmzhdp53sl45sr9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1970,7 +1980,7 @@
     }
   },
   {
-    "address": "erd17vs6n8a33ew6xdmelfdq3ell99k8m72ssvr8weeqvpsx85ed7pkqef58pu",
+    "address": "erd15c3zp5jkyyerh4gve0gwsf75zekdzv6z0qf8639apcjm43ctrxfqrvq3gw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1980,7 +1990,7 @@
     }
   },
   {
-    "address": "erd1jngxgkzfk4lgwdk9v99wqua2n9ffx8ncar373s0rxuww85t66ads4604x4",
+    "address": "erd1skppnulcgpznjd3ddu0txg3x5l5n2afk7msda27jgsgdn8cwsywqxemcns",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -1990,7 +2000,7 @@
     }
   },
   {
-    "address": "erd1d0dyz796520ynpv67rz8mghraalamzafxfvv2gvdd4s7qm309shqjtk5uc",
+    "address": "erd17fc2p22yuegeszkgppq5ntxlp5tmtfejsxuqly7l76meu6ck045qx2gg2m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2000,7 +2010,7 @@
     }
   },
   {
-    "address": "erd1tsccgd65s9uv7wm3m37z6e9rtk6dvte55dxnljxvmkdj6jrd5s9q7kqxad",
+    "address": "erd1azucj3rg0x47k2rw23q5fz0e3uwtnqjj0kmft4dcdf0lr5a6dntqww38wl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2010,7 +2020,7 @@
     }
   },
   {
-    "address": "erd14lwyh34glavcjgahu8q94gd3ml746tm6jwsu76fctwt75654axqqup3mpk",
+    "address": "erd1j443w8mprvhwxrjt9k8czvnerjjxrp459evytccx3atvk5kzq0nqf09v8w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2020,7 +2030,7 @@
     }
   },
   {
-    "address": "erd1p67z6xx0thydry0q4zr4zfjan0yzpkl8eedvhkhyt39schs332psyldz5z",
+    "address": "erd1ntw4pvfpgcpc0jug7jlzp9pdf50zrgska6hm4quklzt3mceqzqcs9fqkc6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2030,7 +2040,7 @@
     }
   },
   {
-    "address": "erd13vd2yllwfk0p4s5779pa5a4rr84gyjze06j59aj6sef8q2qn5dpq2ah4dg",
+    "address": "erd1u9naqgg8tvnnptcx5ujsh4t92m5nus448kdfj7axqne9txpxyq4s4u3v0l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2040,7 +2050,7 @@
     }
   },
   {
-    "address": "erd1zwtqncafsat0ysuwwjam0fh3qnpsqtmjncm8xhrn7hh7lk4zxlys8xhewf",
+    "address": "erd1wuue8r9nrfr7seer36gzzuzqhx9fa2lddzyapr50ch430lvwg9csflxcvd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2050,7 +2060,7 @@
     }
   },
   {
-    "address": "erd1sn46d6jy3nlgssgfapx6t85a9mjeva0gumhc620vjk5kukph4egs9207rr",
+    "address": "erd1nu6et53djvp870s4dfhfe2g59k9wfrscr4u4sa0qj4ckytc3qhpsypy3dk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2060,7 +2070,7 @@
     }
   },
   {
-    "address": "erd1y8ggg2qsnqq90ngwrxgxsrqpdprufz6x23yxyr93rjzs33ydjw8s9hh5ry",
+    "address": "erd1c56sg4q2v8557qkqdlh8lucsrycksg9s6gzwynh9kwdz2u724m3sq6p8qu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2070,7 +2080,7 @@
     }
   },
   {
-    "address": "erd10ty0869fplrhrcua86qnzjmffz20cnnvas3ejd7m0v04jf46vcpqtkef7g",
+    "address": "erd1dta3c2uxrj9y24x5qdnaaytjls0e2carxqsk0kptxe2zhgzvdp9qzk855w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2080,7 +2090,7 @@
     }
   },
   {
-    "address": "erd1ewu8x9quycjcd3auxj5ssggdsjrlz43m2agz9tcnvfza8jgqcj0qtzzg5e",
+    "address": "erd14cnwa0r64y2a2mzj9qpm7u6808989ldgrj4hxffjqr8fguuypzssau2vej",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2090,7 +2100,7 @@
     }
   },
   {
-    "address": "erd1y3uq6dj8lprktpv2uaeu2pel4qhqszlrtqf87vn7wdz3gl2ejtzqm3repp",
+    "address": "erd1p5dfj5806ynefw2z84ucn6n28tp4k9dw93hpv6th87h68rdfnpaqc9gd7k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2100,7 +2110,7 @@
     }
   },
   {
-    "address": "erd1z5lxr6eag7lrfyeqczs93wpkwppeccww66f8f6xl26kc8224eagqqw0g83",
+    "address": "erd185h3yqucu3vqrkxapf6dkgkphe7eratzday2ltvmcq5umeeynttsvffggv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2110,7 +2120,7 @@
     }
   },
   {
-    "address": "erd1s2vhynhlz9rdpdjxafpkdasujs4w4uwxe75ch4a53fqcfx994qjqtq2gjg",
+    "address": "erd1rxwqdk8rwehnh40vxgl42nhzf7yd5l3xnl2jeg7eaptlg9rvzdpsv9zhyg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2120,7 +2130,7 @@
     }
   },
   {
-    "address": "erd1nyhrmeuhtc0np9z3mdvyafk0c5cre2a9mnxhn4z7t2a9pkkgfn4q0623a5",
+    "address": "erd1dmvej6kdwvq0j4qdap4ddqxz0anqrr4js35qql6ttr4jc7h4nn6svcewpg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2130,7 +2140,7 @@
     }
   },
   {
-    "address": "erd1vwryc5drverx5hrjeaatk4qkcprwwnlkvunj7jl52449mcvfr6mql0kxnr",
+    "address": "erd1hhg8djcfxhp8cg5r6cyauw9uwa94y940lh5x0sg4s9mnqt94p6ws6pxtzp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2140,7 +2150,7 @@
     }
   },
   {
-    "address": "erd1qgc0a2t45lsl905hggyrmtn67mwgtvuczqf7ytarq42xz3jw0qfqrn35ku",
+    "address": "erd1q8m6m9whuqy3u8zrpsuysqex6xn5peux8nd5pmehlsau3p4qp9vssfpazz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2150,7 +2160,7 @@
     }
   },
   {
-    "address": "erd1ypwpf8xvxm3zt0r6s86ltm0y48wawpukrs9ws0tmrvqj9n9whlaqp7plg8",
+    "address": "erd13sguzpr70ksr6vqqy3r243srfcyan9syze2knt5n5kndfsz88h6qgn0u2t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2160,7 +2170,7 @@
     }
   },
   {
-    "address": "erd1w824kak4dy94j2r06hp59v5cs2e30xl7yu2pejvm8ru3as2zgefs7p98k5",
+    "address": "erd1xffd8h72huvkdan9qz4eq86v2crr9448ef65h7lzpv0ywu6dwvksxqh8jf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2170,7 +2180,7 @@
     }
   },
   {
-    "address": "erd1k20xzh9667met2tf9ud6s8fqmdr2zn2ajs7w4d5vqnjjrxr464jqj84h9z",
+    "address": "erd1gz0pgx4h7ngtx0zux80pcczhnrfpqvpag4t8pgejumjxhrp99lzsmsgrgx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2180,7 +2190,7 @@
     }
   },
   {
-    "address": "erd1kjggfu5n6xm7ux5usyqty6pxpmupfus0ssmegj4g2jz9czpllelslqh3jy",
+    "address": "erd1gpucz849sut4uatz8xgkjycr489d6knk5j55j6gjtp5xpsxxak2s4pfuna",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2190,7 +2200,7 @@
     }
   },
   {
-    "address": "erd194jq2nk8h7rs4lnzafrcyse5yswpga4jmx00ahawj0cs9yawmczs43hxh7",
+    "address": "erd1pzpaklktr777lka094mx6ddn354y5sra3g3k4e5c7g5ujmn2hplsp0r0tw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2200,7 +2210,7 @@
     }
   },
   {
-    "address": "erd1vzt00pxgdgehmuy7v0xxkley0z52aw98rltw6ytzpjx2kn7wdz0staqljh",
+    "address": "erd1q82he7lrnkdnt8j2t7q9wwksswan0ujhp30lg0sfcj5ns9uxfk8quy2p02",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2210,7 +2220,7 @@
     }
   },
   {
-    "address": "erd1djqsr4amg68h3jddmdnnrqtf62g4crsp5taxwutz7zyau6x42p5q65fxvw",
+    "address": "erd1tvkjelty7ewqugv8sta2cya4erl4wgd7jlm0q4758dutvjr8qggsfcjx8u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2220,7 +2230,7 @@
     }
   },
   {
-    "address": "erd139s73m9ep0wpy8d26lj20dy507ur6mwaqnfk38sv7dyzplfphfqsda4cen",
+    "address": "erd1n2hhcys4z45rjj3xvmqqgegvrfwg7uq5fyndzxd3qxhhdtrs0dmq9ufn3m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2230,7 +2240,7 @@
     }
   },
   {
-    "address": "erd1an2wrwdy6mp27azenccu8zruta5n9am5ufnl6ldjcn8gxp7xqs7qsdgucg",
+    "address": "erd1ycucprjxpn475j0p2rhg6mz55lndx60ua23dv0f57659eez96wssp0ss6s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2240,7 +2250,7 @@
     }
   },
   {
-    "address": "erd1644wxuj3272c4lj5y9lsd3wcc953l0pgef8zqaqmzag8ut7hu4ashz2uhg",
+    "address": "erd12hs62hz4gjf9sdea7tlnm4nq6a8gtl47z5crly5wt6mg6xthp5sql8u29e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2250,7 +2260,7 @@
     }
   },
   {
-    "address": "erd1jyr0f33mwxh592927ca9r4fr8lrgtyfej5kj5zypfdfd2tgx8hhqca5zuw",
+    "address": "erd1gqwz73m3wrqa8g3nh42u7fuup2g5r6akq8r4lt7ahj3dhvhf3ctqp5mlcc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2260,7 +2270,7 @@
     }
   },
   {
-    "address": "erd1zhklnkkesquazetet2f053g0tm3rmpx3xtrc5zy5vlu7hlgdf66qzd9suh",
+    "address": "erd19f3rda4r39jl7f8yww33k5fqtq4slru7m2eqd4xz0gy7kqshustsxateaz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2270,7 +2280,7 @@
     }
   },
   {
-    "address": "erd1jrkk7sm97p9qr4n5jhm0d2km7au3qp8nvh7sgnhw8thhwahuw8cq22e07f",
+    "address": "erd1sxkgy645eq26kcq90dqf6jyseg8h2hh75c96sqemyyvctpjy3ues7q3dfa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2280,7 +2290,7 @@
     }
   },
   {
-    "address": "erd1sfnfrtftdcphnqwp59hkl3p9s56dxvrllm28wa665hqmyz2dsjmqa7zefl",
+    "address": "erd19dwautefstfdwxrf07vmatvcn8quzmj3nz3lkuvn27d45upezyyq6re94r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2290,7 +2300,7 @@
     }
   },
   {
-    "address": "erd1uwg27n6lcaukxahqg9tdvxh7l0pgg3qyjfd898rsve88cfyvw40qz4n2c9",
+    "address": "erd10q7elvn4lwsf5h0p692h8j27k7rxqfy3hfkrjf8tmjqvv6jf5pkqdn30yr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2300,7 +2310,7 @@
     }
   },
   {
-    "address": "erd1w8kqlmjj0gpm3uhgp43qqh2mgnrj8xqv7zn8kwzdh9z6n85qx0dsxt0yg3",
+    "address": "erd14tx0wtxs7k0emg80rzyhzajq37n26326y78ke7fceznrefvzznqszr5zvf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2310,7 +2320,7 @@
     }
   },
   {
-    "address": "erd1pdedsxx4ld4q4eklppfq0z850szhsakkympxpn0g2zte5727nzdqr9u9pk",
+    "address": "erd13pnfg7kpl8hrz77gvyvayaw4prsqj8mmkpdq4xurxc886tsf8s6ssaslr7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2320,7 +2330,7 @@
     }
   },
   {
-    "address": "erd1leu2m62z6d9g0xdwzpm0gg3nf89n4jgawx5rknthyd8sq20u96rswwq7j9",
+    "address": "erd124sq56w77j5wnk0mf4y9ar6elcxzmyxrd5t7qtv55nus3hkumgzqdwrclz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2330,7 +2340,7 @@
     }
   },
   {
-    "address": "erd18srqjt98q40gd6wwjtk9w9gza2dj8l74rcwzkswplse67vm888nqnum90u",
+    "address": "erd1q4hhdvulv9k7s927ehtjamgk4qcc2sym847m0ycq8cphwtqzrdsqst9xnr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2340,7 +2350,7 @@
     }
   },
   {
-    "address": "erd19lh66kek84fe77rxzzctsxtjzs5d7du8u6wrxrmyvrm9pxzzj3kq6cagzl",
+    "address": "erd1wz2eexyfahpdv2g5mzkqkes5tladcxyqcx5gqzad0mjxmf0cunfqagdut5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2350,7 +2360,7 @@
     }
   },
   {
-    "address": "erd15c735ygtmvy9y3950vnq4446zmzt62v4y7aydrhrft4kkncyh0zsckgy4y",
+    "address": "erd1ghskxemex0t3s9l4ryfhvme5t2d8g70ezvtu9yckqs6wsj0uec3sjrun6a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2360,7 +2370,7 @@
     }
   },
   {
-    "address": "erd1wxtyy3x429pmsaqd8weez9mjlw8p2sqgxu7nmehy832cana7h9ysx8zf2h",
+    "address": "erd1uldx60r67hu7qstqekfkavlxehgutechwtm0jagywd94mntxeges2vhqw6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2370,7 +2380,7 @@
     }
   },
   {
-    "address": "erd1nmzqt6xthp8aptpkgr3kf07ely8nk5cpf4jpl2xwpu84wdsrqvgq8tluny",
+    "address": "erd100mehxer3fsf9cd0ymyl2wu3dqsujxjkceyh4qpw607m9ayjdquqh38eu3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2380,7 +2390,7 @@
     }
   },
   {
-    "address": "erd1aq5quql7a6945x4nj2zuqtmequmt0v5xeuvl3k3u4dl297n58wxqrrvq2q",
+    "address": "erd1klqr3cv5kaxdkff3v4vhxt256qh46lvl6sklxg3mwr82ya7s7q0s0ch324",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2390,7 +2400,7 @@
     }
   },
   {
-    "address": "erd1pmeg5nrfnhptwz3w66uwc965n56p8rjusp8ej597jkgf4q7ugpnqhfl89q",
+    "address": "erd19e7hs4ax8mtjgwfgyad0p6z5epugkej4eqpe086lnu50z0khx64sxs2jne",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2400,7 +2410,7 @@
     }
   },
   {
-    "address": "erd1ha5wrmsn4aluhh2gl5hnpaz9cy74u8dhmtlwtacfk37mnxdpnxgq55k9c3",
+    "address": "erd1ma76qfmp0e748pwqn6kp3p5uwffpe5nq8c6hrrykt4rm0t65ej9segx8a6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2410,7 +2420,7 @@
     }
   },
   {
-    "address": "erd1pk9jn2svag7zy0kxan58fxv0fkc9ldmvcsnu6vk8prq22q7qkr0s48eefj",
+    "address": "erd1908j3wxamtsrex2pamahjt748t6wtajn698aserv2gdsyzmm3ppqr4e6vj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2420,7 +2430,7 @@
     }
   },
   {
-    "address": "erd1rvadgjrzxqm4rz3e0gnmdr6l3wqy7mkqxyxtxn5szz9g29kdhycsx3qfck",
+    "address": "erd1zxefdseylh8hut68alqhwd6zrmqpl8lt0lyl064ry8zmxuh3gmgqefcsuf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2430,7 +2440,7 @@
     }
   },
   {
-    "address": "erd16uta6mw70ea7ykp5n4hztsnwepg43jhd4nd4hu2hv8v9umclluhsp9ayqg",
+    "address": "erd17lm0zxuqh4pqescvznprm255s6t68jcme7nr5fq2mexzf2uszgjsnta658",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2440,7 +2450,7 @@
     }
   },
   {
-    "address": "erd1xddqn5sq46hsvujw3sdrsty50lnl0757t0vvsr4akaw539p5l03srclxqz",
+    "address": "erd1nv7qwu8dwkeegvp74pp79f4ppm63sxf2fshltmchdg7c8tw6m0uqum24hp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2450,7 +2460,7 @@
     }
   },
   {
-    "address": "erd1ysux8ga0lmtqln26kyc3h57v77l08w4pufzatxl8qrmdjldwu08qm080h5",
+    "address": "erd10702c6yuxrh4luxee6e75d965uxdtt98px6x06c0ttvk5j7k4efqlklapr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2460,7 +2470,7 @@
     }
   },
   {
-    "address": "erd17q69z6u6sjtqh2nlnjxj68axrr62hpt9nyqnvsyezet60s635y7srz3gjc",
+    "address": "erd1fr9nr6egejem9mma3ncxf09rffptud4lch4hlprxhet7pvp2w5vq5xe7cq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2470,7 +2480,7 @@
     }
   },
   {
-    "address": "erd1w998nssghm74ehzy8xkpwm03hksa6k0umyuj3rfdmemdhu270z4sftx0j9",
+    "address": "erd1xy473kalkr4gwehvlsup62aypwqpgsvvzax43rvg2xpmzt9lydcszm5nj3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2480,7 +2490,7 @@
     }
   },
   {
-    "address": "erd19sl02ytqv6dn3z95qw72g7fkqnag63fm8u4vehuarj55lmms8n4skamusj",
+    "address": "erd1tfrlwlcs8vwaj9fpvkfnt24d93q7m7ufdxtf52xan5nvj7u55g8snlnlkp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2490,7 +2500,7 @@
     }
   },
   {
-    "address": "erd1uj3qxplfd0wvh2fcqfmzyl74fwqpwzxmxu6q5cmqdncqpzz7e0hqf9ftwj",
+    "address": "erd1d6quwt2nv98l5r97ks4z4r3lustaqey8xkxmdz9f5xh4chexhw6s9hykmp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2500,7 +2510,7 @@
     }
   },
   {
-    "address": "erd1vwj0krdma8dvn27cwwc8ucc8xdpz2wg32nuarhr7rjp0jslpnvks5evr0j",
+    "address": "erd10e09lp7zuck077duhvmvp7pxe2un0ghxy7kpsn6f53lfd379tsvs4veya2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2510,7 +2520,7 @@
     }
   },
   {
-    "address": "erd1g74sna3uz6d5vynkft52vru4txgjkfduq2f2sk8e3gnyltztss3qjkqv5f",
+    "address": "erd1tuc3mlvu3dhj8rvsw89wq0cq8qpp3c79x20sn85c9xz2ya9e3vzskanlav",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2520,7 +2530,7 @@
     }
   },
   {
-    "address": "erd1f4xzp5qy2g6s7l7kulchzsz2x6chknmj7qtvc3wwtg8mn7tj900scplum0",
+    "address": "erd1vmpkf7z50duerg3s2g9rths4r0sr3x63sjhxzsa0wwv0zrwh86gq75kra5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2530,7 +2540,7 @@
     }
   },
   {
-    "address": "erd1034nh9vd0mjwhnzffel75dqzn6mzu2vasek5cr8ztykpwavxyc2qqhkhgx",
+    "address": "erd18aqx5ss6lkk6na3g5jzdgwmt24p8rj2sgw88e7g8ymautnxed09q8nu7nm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2540,7 +2550,7 @@
     }
   },
   {
-    "address": "erd1a523aptjf8drtds7s5kgtldnsegrzyyzmxzgde65dde7ycpp9keq2snt66",
+    "address": "erd1xlryn9ssur4m8zsdxu7r3fufe0hrad50pcwpmzjc9vkp9gxjq6dstf90mq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2550,7 +2560,7 @@
     }
   },
   {
-    "address": "erd1nn0kfzn063yelfdrrfulndlr9fe98j2kpqzl2ajk6w5r6cr4p78qc6uc7u",
+    "address": "erd17g6xxqutx5lcp7jjt0dv5jk6mcsqp6qzv5ccqvdnvtapywa8rmzsny2ej0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2560,7 +2570,7 @@
     }
   },
   {
-    "address": "erd1ql9e8syzfy47e39p4gmzlc8546qnxc9yfvn6hyztpuj7cg7we6pqqjnql9",
+    "address": "erd1g5cf55ygp3kupe752c868jkpqffkpljpvujew2t6g0073p23tjuq05uxpt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2570,7 +2580,7 @@
     }
   },
   {
-    "address": "erd1hz8vkgnv8lykcr7xp0za2tg3gkcc3n0f3yz5fdt3u3eex6knrugs6tfyk8",
+    "address": "erd1vzsf6uztz7072qlhsx9q0t4suszaz9jr9gl76zzlen9x08r2sglsanhfcu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2580,7 +2590,7 @@
     }
   },
   {
-    "address": "erd138vhu9leg850hm25j870gy93kz7umq5a53ueyylfj6exc8jfyfzs6pqpdc",
+    "address": "erd1xxddumg2guvfhljj8yppdx2673d0d37prnjupg05ecu896z4v3gq7wtjua",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2590,7 +2600,7 @@
     }
   },
   {
-    "address": "erd1eu8dpaegghdjayf72e9rpspzvmz25upql5m7hnehkwmxanf5hqgq3fwx2k",
+    "address": "erd1t775xrjhc30v0wyzlmgzhq4p5h4mkp9jl6zmzev8dtevkms7ydgqf7rvdd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2600,7 +2610,7 @@
     }
   },
   {
-    "address": "erd18lcfphw7k24nsjefd4jh86vvw4sq6k228qnyy29nxufrek0zr4yq9832h5",
+    "address": "erd1n3gqxzyf9r638ndp32fwdd82kr28jl55vvsrmmlvsqxr7v6u2t3strrrwg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2610,7 +2620,7 @@
     }
   },
   {
-    "address": "erd1ral9c70ru08rdms057gw49udjl8th0jt5024pnt7sx672q3yvmvssmq8el",
+    "address": "erd143r5wudvsgm92av8mzlptv59sqnwqckdvsa87sklsy6c7ktyw7aqy0yjkg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2620,7 +2630,7 @@
     }
   },
   {
-    "address": "erd1sl3dx4n240ymmh3a3jsjr9xclv4rpu6s5ul6qre5jme4pj2x3n7s2ztctg",
+    "address": "erd1mzxtc0g0y0keet84tflwexjcz3q3yt73dexz6yp7rajgvu6s7fxsadmwae",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2630,7 +2640,7 @@
     }
   },
   {
-    "address": "erd1edm8sum5qmdlahkchvn25qhey9yu6t3xxqdz6d2egavxhr4c69vqda8zth",
+    "address": "erd12k8knx3twd8wjhmhjv6xjezrtn6azntuyduc95vfsps4q3gz3yxssak3md",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2640,7 +2650,7 @@
     }
   },
   {
-    "address": "erd1t6ralh75zh9hps74kcqaz0wm3ha2myqjctfpcpgh0n6x0t2vqu7sk5d6te",
+    "address": "erd1f8mey4y9y6rpg0wkn6lfh5klzwpmp8r5z4u5jqzu5l3w530r26dsq8g8e0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2650,7 +2660,7 @@
     }
   },
   {
-    "address": "erd1ppwgwkvjqsc5fl3jekqcwhla4l7unc9avrpv283nk4mt3ggrl98sw93u7q",
+    "address": "erd1mhy66xcn5m56y8xr52m9xk4eaqtpt929qj80yksu8n5wh2acu5pqc79tme",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2660,7 +2670,7 @@
     }
   },
   {
-    "address": "erd19pwtn3zuv7r6usfu8u5rns5enferuh93f7gkvuv7x2dc05av6qxqkaw6j5",
+    "address": "erd17k70xlyv8634gprwvla7zu3hguw7wgshv776sagft480v7qfclpqjrgav2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2670,7 +2680,7 @@
     }
   },
   {
-    "address": "erd1wuf3tush5gzy2hmvlzncqs56sd32emywyzdeuvnmve2awduwmmxsumx2vl",
+    "address": "erd14apsjg5y5ghp57cg8lva2hp86h6hdewgcmsczqkjeh76s9fj8h9sv6nndk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2680,7 +2690,7 @@
     }
   },
   {
-    "address": "erd13ekr37wg5lnwyqp9h30ep5t2ve93krllrkqkepw2zznw9kcy6xvqzjukf7",
+    "address": "erd15kh0758pqhdyf8cvtfc6a5tn5aqe8mwp8mfekdrmjsa3ts09gensyh23pn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2690,7 +2700,7 @@
     }
   },
   {
-    "address": "erd1rhtzwf3yggy5588vvh4mgd5874jzz3ht2fxur28rmjcfxs59j7kqjs3tl5",
+    "address": "erd1v908z3f5z75lthznrvcavc6n0hc8k0uqwgr0mk9tu5lrcztt9uxq6vzraj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2700,7 +2710,7 @@
     }
   },
   {
-    "address": "erd1xyt88yxxkttu0982wqr3gwpfj3anrmk2fxvjn7qtzp3udwa97g0q9pjlm5",
+    "address": "erd1yeyshjhqmqtc9st8lgmhvd8r9jlkyd8h7akkue3gres8cdwtktlsmwmgxa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2710,7 +2720,7 @@
     }
   },
   {
-    "address": "erd1c076vayy5wkx7cjxd62y99rjwhy3lm744ll5rmlttjy2xms5sjwstkg27x",
+    "address": "erd1n0a7y8j66k2gz84damuh6vr6pan6zrgt7kyklf5jg43ljkt9ng7sfeuq2s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2720,7 +2730,7 @@
     }
   },
   {
-    "address": "erd1xhwlmmcy5pspwwy9kxl0tvma6txn4q9dy4x0rzdyddr6pyxf630su7gr26",
+    "address": "erd1xqsscfq77gjgwzmcz4ckejmn32k2tvyywatwc8detmeucehdex7qxqlvm0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2730,7 +2740,7 @@
     }
   },
   {
-    "address": "erd1hw6mrl4k70ld6jdrxt07d7dvhzcccegr6yc5rgn22usd4grcw6rsjnh7v3",
+    "address": "erd1ccq78vzehtuqcn5jfcqrgrlxdtnxrft3zc8m397hpkfn3sr468kqd7y60m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2740,7 +2750,7 @@
     }
   },
   {
-    "address": "erd1lhs52wdp3z9fcme8aae9c9zjg6uhsmg86s4axu2w24uvhmdkzhksu20nml",
+    "address": "erd1fq4v9va3z80xf2tjve8fqzxj9t3hwend27dupaavkt8perualc9sw5g6vc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2750,7 +2760,7 @@
     }
   },
   {
-    "address": "erd17atkthz78zw445ux25k0kh76mynwykcfzlsgccyvexwxqel0n0hsvyygj5",
+    "address": "erd1d7v09y8p7d8xktds94lh9l8khr57k8q5myvvpctpaqgnw7kdj08ssf0ehg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2760,7 +2770,7 @@
     }
   },
   {
-    "address": "erd133tfpa58v48m9ntvzcx6gjramgsdsf9464sa0zwqtsjv9m2pfrjs2307mm",
+    "address": "erd18zj3as6ufytlm6v2jy4xqq5zc9a6zctuaz3d9j83q67crpa0mk4q6a08pn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2770,7 +2780,7 @@
     }
   },
   {
-    "address": "erd1rxacvsyz85747ljpu0ry6cwtk5wjtfs879pxem4t7quc8478wk6qu3qla0",
+    "address": "erd1hw6wf7nmfndsa0qz6kpn9ntqjlnvq2msa9lc5qs7qmrva4gckrsqe3mcmp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2780,7 +2790,7 @@
     }
   },
   {
-    "address": "erd1fklsvkawy5zx4jakfjzakf2wlmjxy2efrfremj7hjv3tzhkfkw3qzcca3h",
+    "address": "erd1c66kzwrull8ypa38veeu5dygczk9rtqhwlpphj8stu5r9y003jwq448vxe",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2790,7 +2800,7 @@
     }
   },
   {
-    "address": "erd1phck2t7gvsczpylu7z3ne36zwpmtac9ryw0majn8uqk3jjh8tgcsez77p9",
+    "address": "erd129gpe9cq0578daj55mrj8k5ymsewfz3l4l3nm3shzk7zjwhjza5qxy0yyt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2800,7 +2810,7 @@
     }
   },
   {
-    "address": "erd1cmanwyhg9n9vn2a4gdf02l95azgjruf0nr8q5jf62dqkhdlc030qhha3d9",
+    "address": "erd107vtr49hvp92j3lxjxzts8xqlzxjyt546hwfg3peaymx4xa835aq0h687t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2810,7 +2820,7 @@
     }
   },
   {
-    "address": "erd128y8xwlmrxqfleqndx0qs0wxuulh0p950pp474gkyc76wu0lyneq630sdv",
+    "address": "erd15q2xph0m0dflau8xp5c7fdrn9jc8ax3qccat0w4e5rryr6uyvzcqzqtsqs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2820,7 +2830,7 @@
     }
   },
   {
-    "address": "erd169ecujahat22n6fm39skevjk3lg7dwyuwprcf8ljlq729j6fvquqw9sdfh",
+    "address": "erd1n7d8tkt2ulkfs0np5p9jtegd2fzeannx2wvnmhzywu564jyfplss9hkxw7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2830,7 +2840,7 @@
     }
   },
   {
-    "address": "erd1cc0tvry2flchlrp82fd9nhxdkm0kjdgk020599m0pd3xx03jmmsstxypax",
+    "address": "erd14lcl90pw9pt9p3un628lgl3drgtsvxlgcpwal3ee0upxgufegudshlmadc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2840,7 +2850,7 @@
     }
   },
   {
-    "address": "erd1rqs4rfca0mlkz8p2twavnmakx98vnxwcprmg9vgdcl7x43ukzm2qevyxpn",
+    "address": "erd1vnftrghchwucar07wgehajupq3kpmr66wv65ece09vqfz94kcw7qfas6vu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2850,7 +2860,7 @@
     }
   },
   {
-    "address": "erd106w373jclcc4vd9n7pq4hd69ugmuezhry4mtqf7qhy7thclq8urql0j84z",
+    "address": "erd17c0wnpjsr0pghv8f7jvs547mlvyjacslwevrw0m7ghth7acfrj9qu499fl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2860,7 +2870,7 @@
     }
   },
   {
-    "address": "erd1zc6rla4dy0e0kah2m6h5xxlymh5faznjcnpg0mkakx0g2h5d9dpsmpcu3v",
+    "address": "erd1g37t4dp0ameycl6p2aphxkzqr84l669hwa9uutzs6x6l44ms9v5qfyewff",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2870,7 +2880,7 @@
     }
   },
   {
-    "address": "erd1zzvkvjht07plxdcgdravhtxwfluvkunq40qz8k08ey2c40e6f5jqe8gww6",
+    "address": "erd1fw8k7fmhzg87dk7hzgq3v4nakk5dhu0558c8r6gwwryjcr2deegq9xjgas",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2880,7 +2890,7 @@
     }
   },
   {
-    "address": "erd1guwugprrd03rayzyn0x06pgpyx6epd9w5c7gyxx2qjyk9pm07hzs9m4mpt",
+    "address": "erd12j8ae7gxzjvwlg4xhx95kr5wv759ntetg7ueu26crpps4rzxa5zqqe5waj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2890,7 +2900,7 @@
     }
   },
   {
-    "address": "erd17427sjkf66gas83f6jr0rtm85swwguywsfna2ac0pzxwdqcd6pmsskv00h",
+    "address": "erd1w8mpzhwyw8fsv03sctceg30sgmhmdw7nrujqry025hkqjghkv26qtzelty",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2900,7 +2910,7 @@
     }
   },
   {
-    "address": "erd1g2tqnwayv8wzlfjsrxmaf9v0p9dgwxjrgz5rk22tls552z9vmc3stkrcja",
+    "address": "erd1sa6hkfd6car4vd754ksqum7k6p4chpy5r40ymcle4fw0kucsu66shqmhy0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2910,7 +2920,7 @@
     }
   },
   {
-    "address": "erd1yeuzdrtq062x2xp09fdvzh2qe2uceuuedp7zkmm43u535y9ydynst6ftrv",
+    "address": "erd1mjhfa6f2f9qtzpfxat06pyynxxtrpn26mc3tlzf9exldzfv938lsu84csh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2920,7 +2930,7 @@
     }
   },
   {
-    "address": "erd1mjp2k0jxaf4kv7j0640auf06hczuj5lg7u3gjs0dg5anhylqq8ks9u35f9",
+    "address": "erd1sgq9r6q7dt2drq4rrgtvsdtm6960l8ea2t9up38s8zlpd9zps0us2fal8j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2930,7 +2940,7 @@
     }
   },
   {
-    "address": "erd1grtk3wsy4cnhsd3yj7d39kme7njqvn9syesqptyrftezzaww4yxsmahvzj",
+    "address": "erd16wkht0294xlhshaz5qh9jgs9ynq3fcwpp5s04dm9rxgep5e265gqkkcxlz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2940,7 +2950,7 @@
     }
   },
   {
-    "address": "erd1nxc5dzxe4jexg67ve43uss70aks3yj925538szgrnjtpthydcpdsxs2ka8",
+    "address": "erd1hztxppx6qrqksz7zcrrv87czt5nl5jgg4kd6czr9mxg43kmm5f4qkdmf34",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2950,7 +2960,7 @@
     }
   },
   {
-    "address": "erd1yag037vr6pawa0tn224x9w06tulsu9h8ppwnajvkewh8rq8u0cess8gkcc",
+    "address": "erd1e8wulfvdxug46vh5qyfkcjlx2trk0v9wwkncmd06mtmtsnl7r2js3c9c80",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2960,7 +2970,7 @@
     }
   },
   {
-    "address": "erd17pu9e2erwe4h8vl394sqnmawu59w6qdd898pr520042pe7elcggs9mkfc8",
+    "address": "erd14nh2zvvcpzdstk9paguzqswlf3znsegeul538n663a67gyzfu34szmm0kk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2970,7 +2980,7 @@
     }
   },
   {
-    "address": "erd1jr774ytvncgvexxejx5z5hv3mf9jxwcvlc32f0purnqx3s65w0qq75erwa",
+    "address": "erd1ve9c35qn9p2rrtffe9atp3haut90jqeujn95gsxmwnje88d7ysdqqfxvl7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2980,7 +2990,7 @@
     }
   },
   {
-    "address": "erd12w3g6qapw9unmfn3pke3chv4z68339nr7tlj7rgzk7yrcxvjt3uqd30cff",
+    "address": "erd1nffvzmwur2xlns9a6gfuf6zedljws5xrjjce6259hhgm7q5jjgzqtq2x4y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -2990,7 +3000,7 @@
     }
   },
   {
-    "address": "erd1zs5vsays4vyxxt9w9gk8ee6kv0dx4g8a3580qelugnl5vacznv4qdug5zt",
+    "address": "erd1arv6ft5kqt577u2nmu6le40cetjdfaysvulg2vznfazpma6qj6dsw9jl20",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3000,7 +3010,7 @@
     }
   },
   {
-    "address": "erd1vacjdh93re0ehvsqfxnx62a7u9ck3gsvl2qyxf4v20xjp3s6ymyss0qhf0",
+    "address": "erd1dc8dhpk7qx0njsvkfkjk0epfzt83gpqvcqa849sjv4asdkxzd8pqf5xdzv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3010,7 +3020,7 @@
     }
   },
   {
-    "address": "erd10nzj808zt2k55qj6j7gxrms9u5y2z5qvdhyfq65qcqpdry3crhksmwr5gq",
+    "address": "erd1ujvhw2ves3ux5n8f4cpdty94hxneyhjqdlj8k6jqdhc0gg50xygq57kyvz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3020,7 +3030,7 @@
     }
   },
   {
-    "address": "erd170cjq9wzk32kra7vg365j79kk49p37qjeq7hdedvsajtymeufj0sdcvdh5",
+    "address": "erd1lc2d34utk68ft9mzgqasjcvdssu0zj3qwy4vlwfnq5hy4h67lresmls7um",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3030,7 +3040,7 @@
     }
   },
   {
-    "address": "erd1f53xunxhtz3th69g5pc0qxh4rsrwzxmgk6gnzce9nx6dap77gavqt4j9ml",
+    "address": "erd13rd8we3ul85hzne9ykpg0p9rls2k8j54uznqlm79lum49kujm7eqlm43qd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3040,7 +3050,7 @@
     }
   },
   {
-    "address": "erd15xm7hp8l3jgnnzw4dwslxgk695dl47ydcuv9ae3cdevrwl76ln8s2sxff9",
+    "address": "erd1uyfpvxzqhnu7af3g3ad0msv2egzjtve4u5a393xa278z0p40pzrqe2cq6f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3050,7 +3060,7 @@
     }
   },
   {
-    "address": "erd14dw0h2t35d766a89q4c83n8xhfhkgtkv7stuz4g0f6vfdugazd7sqvnvph",
+    "address": "erd1st76sk7mwtp64dl8g7ehtqjr4wct6wha4pxs62grdz807cx9m56qu4ltah",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3060,7 +3070,7 @@
     }
   },
   {
-    "address": "erd1shjdyl74cry35awmasgq4gfheftkh4ezg9vq09cqna4w5u2x7hdq2l55wr",
+    "address": "erd1cllj0dfgu7rgmyagrdkyec83vttlptalr0s3qwnp2pmeprzv98zqzqshvx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3070,7 +3080,7 @@
     }
   },
   {
-    "address": "erd1wfvdp6h5je5qa6cakpgv3rx9zecs5fjrf7h9cnnxtc470zuznu5s6cl8ld",
+    "address": "erd16kscyggkxz60x8r54f3dtpup0dxt8awlw2jmml4aejhx02dej6hq0udyja",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3080,7 +3090,7 @@
     }
   },
   {
-    "address": "erd1plu0czvwsdvkm2x3jgh23szssxg9uktv933qxvkts43dk4gy06jq23kz3m",
+    "address": "erd1fjnkzn0mhvmxpqy38uvrda0me755jdzjzufz4sm6gg3emctrdf4su8k72g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3090,7 +3100,7 @@
     }
   },
   {
-    "address": "erd1qzkhgzmu8zhlqkv3tnm38gf6j2qs429p2q2mq90y760quvp8a37q9cd2zy",
+    "address": "erd1kpuntjf25cxe6qdtwthns3lmnseexjvyfznguns8jyuxzux9gq3q8kls6t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3100,7 +3110,7 @@
     }
   },
   {
-    "address": "erd1aqsymqyh09qw5fszkgkhv5h5du6gmqtshxy7rlmylzdl5ns72e4qy2l2yx",
+    "address": "erd1nk8p7h7yaw6whhr4u25jufsxhs4rc0h643jph89rfd3dz2xem8zs3vafup",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3110,7 +3120,7 @@
     }
   },
   {
-    "address": "erd13kpxuvc88rru3vltst9dvus6k72qk2wgcud6n2dylwvdq34pn0gsc78gjr",
+    "address": "erd1eqlajpxkhtks7wy6yzhm27ep8ngc5dpd9twstylvxwptwws9lwysf6lngj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3120,7 +3130,7 @@
     }
   },
   {
-    "address": "erd1zknql24tlecglj6jygxq7l0tjm58l2ygajpylqe5s0ta98fflagqy0m9vy",
+    "address": "erd1dwjhduc7lju8ysjex3e34j494apy5x4dne9d994runsn4wwhcz5qfmthkt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3130,7 +3140,7 @@
     }
   },
   {
-    "address": "erd16fypg3qdp8hu26ct5rlp4py0m9gwuw79xygwu3fltjjvvh386anq57uvsc",
+    "address": "erd1suxd4shj25pdpmgnzm4m0au9f5kdyran6aaq454szpuzynmfmgks0c0p9f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3140,7 +3150,7 @@
     }
   },
   {
-    "address": "erd175anfcswzufjm563jp07l6lkwdry7lrap0xwle99y9lujkuyqvequz3ev5",
+    "address": "erd17p82jxduntjw4nkkd0xqvkqgqcnnsrt244dlpnye72z6x0ns9rvsxvupd7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3150,7 +3160,7 @@
     }
   },
   {
-    "address": "erd1pje4hzhlfhzwxt8wkauzw5nd7f3rsmju35wzv209k4mcngsxnurq7nv6j6",
+    "address": "erd1efpgct5j6670yh3glgzfzs7pjxex7ccvdqp5nsneld7qlpasqhfqctyhaq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3160,7 +3170,7 @@
     }
   },
   {
-    "address": "erd1ly2tkp2jv5n2mxgzw95gz3vt4epnglwgw8mfzazc2q592kvd5rhq6m5szf",
+    "address": "erd1qdy6ntygte44d9j9fv885ztmqr45dp733l6ysf2x64ssgzcwv5psetfrzj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3170,7 +3180,7 @@
     }
   },
   {
-    "address": "erd1ukepweva42qec9ft09hrz9jemzkdhp79cw363al98vqnerqrmwcq2rvdf4",
+    "address": "erd1u4twxtjcavk9lxqhl273ny2jlp7jcanelllwx804qdc7vphh50fqnctu2x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3180,7 +3190,7 @@
     }
   },
   {
-    "address": "erd14r4usuhv0ye3czymu3gqda0x7jmrhtdjqs20up4fj4agfz36yrsqn3nc77",
+    "address": "erd1uwcjzkqpg7957a48e4pvhy23cez9mzuw7pa7gm0rf579mllwqa2shmk6le",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3190,7 +3200,7 @@
     }
   },
   {
-    "address": "erd1zes22exjnvdxdjugyedn8mackxsxyhffg67g7ysjre843mp5xxwq7cxau2",
+    "address": "erd1xqcrx64zfdy5tr0skwqd3ngmktt2wpc6v2fx9fc3fm5cf5k39keq3v3ul3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3200,7 +3210,7 @@
     }
   },
   {
-    "address": "erd1cy4stqgjcx3jj0e2lyfwsn72mswlwymymydxpzgprm4q2885hj2qz0alxg",
+    "address": "erd1fm0httmyfy8c5ma3m9vxg7zq4yl22hltckqfnh3edlzxhgp589xsap5llg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3210,7 +3220,7 @@
     }
   },
   {
-    "address": "erd18203kh63x732g04dnrt0sgwdsl9pc4d44qrpu60pyn48rnc0fqds6d9sjw",
+    "address": "erd1sf9fkcsgz99nnhs0eavtcyjn0m2petdtamulvvm2lmdhstqzlqyqald7tt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3220,7 +3230,7 @@
     }
   },
   {
-    "address": "erd1xqjreycr20gk2nrumrnd38arhz2vzpqct0gd6g2cfjxwr7fz3vcqrp7tmv",
+    "address": "erd1zqs8ypnsl37qgtqvxq4e7mxjqxl4fhz3ecc9wr929h29q560z0xqvzxnjl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3230,7 +3240,7 @@
     }
   },
   {
-    "address": "erd1xmlqr29rs3gf92r8v5mfgxaqm2h369jazvjtap6vc0ewawgpyadq98gch4",
+    "address": "erd187ly9m2l7rvyxud43xtylpgf6ehmx5y2dmzfhlrwzkz98ga42caqm0xsns",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3240,7 +3250,7 @@
     }
   },
   {
-    "address": "erd1wjvcmzehxq27nsxz9agld9chdnl2wneahcen9rn420nelp5zwrdsxn59rd",
+    "address": "erd1t9aqcc88zhffe2dd7nxah6lxdz0zzxhp9zqrd2ym6nrkp08wgu9spkdyzj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3250,7 +3260,7 @@
     }
   },
   {
-    "address": "erd1m4aesg7xvxpl289dslr90v57wr7ftn6refvww3q03skw586jufwsfy5ata",
+    "address": "erd19u2t9c8m5nz0apmympcfdtv0kwfq5p4qmk90lljrfh4chsyf90hsfk9yl3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3260,7 +3270,7 @@
     }
   },
   {
-    "address": "erd14fz536gq8ztd7yfs38h7sctd2khlvlwywm5e2eav0a67rry0u0dq3rgjx5",
+    "address": "erd1l9xwnvezysgg2uj0k4kcarzjwe8pe5z8sa0ztdxa0ctctfc9mzjs3cz85t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3270,7 +3280,7 @@
     }
   },
   {
-    "address": "erd1n5hx6v8ux7zaanes3we07jk0t7p4k38syzumxshs7u0j2ns4l9cs2dn7gj",
+    "address": "erd1gjpxm6czp2za9q236d5dkqfs7k0xfj8llxtemlmmrvdsza5kyl4sw8q5mk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3280,7 +3290,7 @@
     }
   },
   {
-    "address": "erd18uzyfhlrcrqfg20562lz2z25us4fjna77xhhexqvsvur34ds8krqe3l84t",
+    "address": "erd1hahup7ts9kduqp4vrpslzlm932xszcgr7udrgew8m42puzxczuxsx5vmya",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3290,7 +3300,7 @@
     }
   },
   {
-    "address": "erd1x7r693u2g36ey4d9w66vegu6x77yyxm4kdqv9fj3d2t0xftt8gaq32s2hm",
+    "address": "erd19qwy0wqhktq6v3ke0sxr7tzrdvau9f5gg0qx9vvqwtgj7y0zrllst37pcj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3300,7 +3310,7 @@
     }
   },
   {
-    "address": "erd1kq6dsjx8sc3suva3ahvnne594vn8fecn4l0pd2e8vp569ss0283qn33vpc",
+    "address": "erd1gs6ph4qx7rj2geav3q92kr2huv37fcpaul4jnelza52u9p9cq9eq8ffx52",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3310,7 +3320,7 @@
     }
   },
   {
-    "address": "erd1ea25q474p6y3wm5plw229sdcgxplxkrf0v2xjdll9mp0qwg57kysm9tw59",
+    "address": "erd13s4nrm9fw2rys0qf2q2jcey54wa3ysyyz284yapxvmau08zyx0xsdsrc9v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3320,7 +3330,7 @@
     }
   },
   {
-    "address": "erd1753pecp9y8e64tsfkeyfqzx7u9j2glseylm8yvkxqczt7s7lwvpsscc279",
+    "address": "erd1hyen630v6lganwg7cnycs4yl39agsuhky863ly9ze9dcgkdqtctswy6nth",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3330,7 +3340,7 @@
     }
   },
   {
-    "address": "erd1wgr6093hv5ucylw7pdzfqj5l3989402ghrmajs9zmlhnr3xmsfeqyejnsr",
+    "address": "erd1zu49rk2pvcla4kly8uwhaqd26gphyrt6qkujacldeu90ppyj8jcskz0uk8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3340,7 +3350,7 @@
     }
   },
   {
-    "address": "erd1w7eew8szkhjqnnz5vf2a8hwuwzhus2rw38qsmyrjzlvgmt9engqsgm38fu",
+    "address": "erd16kf4w7wtmqnk259ltsvzm0s86vkycue6ncsqjg8knunjxaeu92wqqv0jad",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3350,7 +3360,7 @@
     }
   },
   {
-    "address": "erd13xtnh0afppjtualakxvztasz8weaak7l2m2pjx3smfhhghh580vqk9vw82",
+    "address": "erd1feeueqpajkllvalrjy0lkan9j3vm8a8j6xhd0xknrjpcg4auuh7ss7jd7m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3360,7 +3370,7 @@
     }
   },
   {
-    "address": "erd1wa8ghelusuvmm9uf3npj0mt5wgag9g6qpcr75yy727gfrcvvccqsh7qepe",
+    "address": "erd1kljamr4mhlkj7mrn6peqkfevg8ft6jzt6d99st9t87ksn0reffvq8cz5lh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3370,7 +3380,7 @@
     }
   },
   {
-    "address": "erd1mqmgcyehxuqlz5j97jg6m57d3uvkpvs9myqtga4hh4rh3qrmkjyq55v99u",
+    "address": "erd1nh53qqd26frsu593vndw7czjrp85kv92h3dwgefkmldewtwlpz8q99urf6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3380,7 +3390,7 @@
     }
   },
   {
-    "address": "erd1yn2rjljc3hsx4alyyu9pcajrlws7sfvxcaxz03zc3wc9jrxhlemsmh8ngh",
+    "address": "erd1pt965zpexkkhfjgw3czndc04th649vrqqu0q62rlw5cfwyg7atfs6kmkes",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3390,7 +3400,7 @@
     }
   },
   {
-    "address": "erd1xvzmuyq7wag9yvm6qh8mk3z3kna0eskv0hft2egpx8msr5mejzksl0zxgw",
+    "address": "erd12vgs525qxcpndw2e2w6rycqv3p9re65w22ujruwpft89e6gplgyq22m76s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3400,7 +3410,7 @@
     }
   },
   {
-    "address": "erd1497uw27jkvukx5k65hm427q4lxsrk93tzkud7je7k0sdgy8yd6vsa0z0k6",
+    "address": "erd13vf00twrgfa4n0nkhl0whxdf7pf8nss2g378dnymyjsgr2lkgwkqk2sc29",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3410,7 +3420,7 @@
     }
   },
   {
-    "address": "erd184yq33zkpccv9qllp4mkztjxpeeqd2gytf63g67wz2vr6ll8my2qk0suct",
+    "address": "erd1a4fkgu9l6dxl820fphnf47tm5w5gm3462uwnzxfc3nzxxrqyx2aqym9av4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3420,7 +3430,7 @@
     }
   },
   {
-    "address": "erd1pmkdf2ccfnuvkgd6q8xaz7l762kywvgsrefmkchwa0prgaamy6csvjv69r",
+    "address": "erd1s9x6g8fsvxz2quj9v9k4csavpyc6hvx9hu76jas0vr0m767mw2wqh06gw2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3430,7 +3440,7 @@
     }
   },
   {
-    "address": "erd1a3de8nfty5c0j276a68u065dnzt66wjwzvu9g87prxc3xvtj7r2sdzddpg",
+    "address": "erd1qvgw9sp0d3ypqkg32ar869h0k95pzrkw3p97gqnvtqf6adkpj9asuaktng",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3440,7 +3450,7 @@
     }
   },
   {
-    "address": "erd1p9cwgs3x74lyqkm2wn0s997k39f7ljda7chgjp76lswee34qn77safufr7",
+    "address": "erd1yv8l5nyaanqea7a3a5549khj4jw5tzr0hlp49gy4l8z857p0quws5h6wxl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3450,7 +3460,7 @@
     }
   },
   {
-    "address": "erd1rlglxu8kj8agesksxgqyu4zdhfvl08c2klt666l5mtsu2ds3e5xs7xwdzh",
+    "address": "erd1wjdp6e4awedegpdya3nfa54zpx6c3ql3xt0pudjvl4mea4ntp5dqtpdc7e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3460,7 +3470,7 @@
     }
   },
   {
-    "address": "erd17jxy9p9dtrfteparmjd7vdwt573wvazlrhutknxfemkqcgmqr8lqh42v5r",
+    "address": "erd10x7uepaxtzwdlrccsqac60pu85vvlnta0awtcwte4lpap826nj5snqxhj2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3470,7 +3480,7 @@
     }
   },
   {
-    "address": "erd12rh0vy0l34z0j6pqhg4t2chk7xvrry7fuqvzrxlga06ysyz6l45q5p4w5y",
+    "address": "erd1g3tntpq2g0vnmxc66mmud09dmpwahf7m5grm99ltz0z884g8ce5qay4485",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3480,7 +3490,7 @@
     }
   },
   {
-    "address": "erd157ecvjj8f49ykeyl2wvuneuyuyvdnkezue9vvjxvtfjgxuwkka5qk592hd",
+    "address": "erd199t6eccakptj7j3825r8m89gvspesg4degv0fee63kxrnlhs7lkqx6v0vf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3490,7 +3500,7 @@
     }
   },
   {
-    "address": "erd1umcwg0c6kqctgwarlr52ly0ann6vlfu9kt3fa4j0nxp8wyh6wl7q8d5skx",
+    "address": "erd1fx3anvwnjefymwcnnkf7fc8dp0y3tsylygst0g3flc2rhnhwluas3phx4k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3500,7 +3510,7 @@
     }
   },
   {
-    "address": "erd190v2grkl97jpfwgjx0n0u6wwt03x7vsmadn2lw52aj5k3q0m8xks829433",
+    "address": "erd1zssaw37hv4k78m8eqnpxdu3hkt5xc8dls6j4kfma540g2ddx5ldqepcsle",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3510,7 +3520,7 @@
     }
   },
   {
-    "address": "erd1vzzte6c6aeymlnepl6ntla4h6glqh8gpqhgm5jnup8g7ctwvq3rqhngr82",
+    "address": "erd1fj977h07r6nmn0evptfp9t8pzv40nw8y289dcty8lz20ce78qfhsrz0kqy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3520,7 +3530,7 @@
     }
   },
   {
-    "address": "erd106nszcav5nn9lz2gw7nmyaada2f8hr74dqu4gyd4p0n3jzlr228s5r277c",
+    "address": "erd1qzu233a63eg0dry9z7e4nyzsktnqrx56ck5jg7xtnf6falg526ws48xq3z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3530,7 +3540,7 @@
     }
   },
   {
-    "address": "erd12gx4qjq6tqcuu0rpcv2g7eg0lsk8pug40ezg6ty6fars44e4pr2svnd3g5",
+    "address": "erd1cdwunhuka4zrcqksfmar2k99q9a4hzkv8ar4lmlcwqdaskvdht2qr23yst",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3540,7 +3550,7 @@
     }
   },
   {
-    "address": "erd1xtqzdhawwj6xjuhwxgu5jz4ukzh9d5x2a2vdm2wcc8q7lr0qmf6s22dqfe",
+    "address": "erd1g20s9wwkkl3ypvnlwh6r6gxhzwsku4uwhtk2gv0cunjcx2hlvrhq66v3n2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3550,7 +3560,7 @@
     }
   },
   {
-    "address": "erd1emz50qdqzawv7uezrg4sngsfa3d8v6t63a93u70fq2yt9m29rlnsdqng9q",
+    "address": "erd1yfymc8ud7ywl05treh0u7m3e893mqz2zh35kadtk2paqf5yutzxqy0ez55",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3560,7 +3570,7 @@
     }
   },
   {
-    "address": "erd13ajwg6wrwqtvv7wmwmdxr2xzq9mfk4qe35fkkqy30yzeuhhxa8ps8uchm8",
+    "address": "erd13p623tfhs2hz9cx3xfwq600y24kur50hpwuq6x6nq75ecmgwz8ps3ezlpa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3570,7 +3580,7 @@
     }
   },
   {
-    "address": "erd1a4mye8xn7qenskt03dwslj2q9ppmscnlhd0usf07smymfrphr5xssjq3yx",
+    "address": "erd1fuw5p3m3f3lj9f9uyclrqx24264c4w5p5hf6tdk3w0vg6afnxkdqt469p0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3580,7 +3590,7 @@
     }
   },
   {
-    "address": "erd1kg0vkay8vnrlt0k8gmqqv4se7z5d4fjyymsrl6zgkvkcgj4fmyzqpwecd3",
+    "address": "erd1sg5md93k07x2fndj3xf2sm9mxf9udhzjh04n5qn4jt8ulgvzq9xqg76ztt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3590,7 +3600,7 @@
     }
   },
   {
-    "address": "erd1zfg8crzjl6wtxzmqzy3avpthzwh4s83je6yn2p3gj2xuk5dem6rqvpzju4",
+    "address": "erd1zj4je57p7tjvxtnwdfjxz3ze2mfgqwd3ajjlsxpja2np5dy5u3dqvlzcat",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3600,7 +3610,7 @@
     }
   },
   {
-    "address": "erd1yp0jwk0ekmtt6quaj77mk0j7ftnjprr223zzgcwrwf4np8te2hgswuyh67",
+    "address": "erd18k4hgfvvlejh6kzjn5yy6yglevzjjsrhknzuhyzj5k0h9cvt3wrqu95085",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3610,7 +3620,7 @@
     }
   },
   {
-    "address": "erd18h2y73k4pgcgjquy304r8039dtwqrg5r5k8c7pg5psrl6zs3alfqwal9wp",
+    "address": "erd1nwr90e7z3phx0x86ph7cahr9l8dr7re9dvw7xejz3f407kcjc36qgkffzh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3620,7 +3630,7 @@
     }
   },
   {
-    "address": "erd168q6val8jz4x5lpf4elles0j6dzvs8ufpewpxhpkehnl76ampcgqneyfrv",
+    "address": "erd1vp0302w7k2plp7c7qa2hw44vhll3ltff7eqllc2043eejx7vq35ss4tjjd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3630,7 +3640,7 @@
     }
   },
   {
-    "address": "erd18se45ay9munfae7h6mzt5gpjwuwlr9ym0ttd5yw06fg0pqh4lpdsqfpmus",
+    "address": "erd18v2jw4tagyjj6amp8gfch50keyhe52fxs0scu7s0fepe43vu887sjupj6q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3640,7 +3650,7 @@
     }
   },
   {
-    "address": "erd1emjer527kyeaasgzurvwfrtjrf4ma0t6nkaxxmq59vqva7wq6mnqczv3dw",
+    "address": "erd1hrju3s54tjtxuczurftqf2ca27983qlnd6e6vh8z7wveuv49rmasmwhn97",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3650,7 +3660,7 @@
     }
   },
   {
-    "address": "erd1z483kjte38em40x05mrvehn6a6t534hy8z3zlm3cdmna7tfde3tsj5huqf",
+    "address": "erd1fhfm88pklwkqjyuy94mhy06h4c5ffzywe805d4e663ksxgn2e20qtkqf54",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3660,7 +3670,7 @@
     }
   },
   {
-    "address": "erd1ry3xeapx8t5s6uuqd4fwgynwp0ylw3hn4c2tudg4ykyay8q38rjqg9jk42",
+    "address": "erd1suz0y5ukqtcjntzgmukjda4hvapck2xuamr8nzd0crc3upcut7sqg7j7xh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3670,7 +3680,7 @@
     }
   },
   {
-    "address": "erd1ldqc3hawc4d4xfl6an6fardydp5c95zu2aysdznw2vlwrwwuxy7s02y9an",
+    "address": "erd1s60v6w9r86vr7xf3kx0rp2k9kwxtw8xhzvvefay360y2q5csn5xq28cy73",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3680,7 +3690,7 @@
     }
   },
   {
-    "address": "erd1k33w5rqdgt3wfefzzah9lr2c84xarsd8zlt7xg4r64hykkvt4g0qh3ctuk",
+    "address": "erd140x6y4gv2kfg0ht563mh97clw9nln2dumegjex5hn3lpd5sljntqvv82dw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3690,7 +3700,7 @@
     }
   },
   {
-    "address": "erd1h5m43p7puus76kn5f0eg9y3m5gv796c9m06pan5nuxd6xc26knysp6km4a",
+    "address": "erd1szum0z4zmkha7pd73rpd5fltc2nxt2afpamnq58n2cue34dv7d7qmpkl4w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3700,7 +3710,7 @@
     }
   },
   {
-    "address": "erd1f3udy8hnngz9dstp5jvjg3y3q3ldh3wmusrtd3am3gpx0fyvrjss58ays2",
+    "address": "erd1mqsvyr8haw9a8wdlfchquhz2npmvuzcjzecmtqycuw0702fzng8sstldwf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3710,7 +3720,7 @@
     }
   },
   {
-    "address": "erd17nlnhdfd0hzhntl7mcdtac7ge7hl6ckqql2tj9v8wk2d0zhm0ndsfwdatn",
+    "address": "erd1tssq7cu4y59zan6qxc3lvzsk70wwmf4fsx8qfc569fahsv4m0ntqv0fc2l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3720,7 +3730,7 @@
     }
   },
   {
-    "address": "erd1h7kru4luzdzvnvek5cvx4pdqq2xp5rxm9jxmxg7gm87jshsxz6esdeaenf",
+    "address": "erd1z5dccucrjjzhpklclzn0cgxuz3ga82valvca55jnsx3js84ew3fs908k8d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3730,7 +3740,7 @@
     }
   },
   {
-    "address": "erd1lydva4rzw0egc8zgxw6dnyeptyjx7n02w5aru2x4a7gpfuk9gtzsymyu8s",
+    "address": "erd1waxkuff4hsx3efu6k3l4wu0g855jph44kesfgvgmrt09ga2z0vuq49t3e6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3740,7 +3750,7 @@
     }
   },
   {
-    "address": "erd1r7u4j8249a0tsxt0d8tmrw2zmk3edm3er6yctf0sj24ufgzysmdszwrk6j",
+    "address": "erd1xcjflfvh3dlx9vu8fn58g6m449nxf62jnfydhl6qa3mzc7mskmyq5gv2d0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3750,7 +3760,7 @@
     }
   },
   {
-    "address": "erd173thhmjw8layq3sp9f5g5ymkycqdz979tawst584emaaaevcvetqmvxxq0",
+    "address": "erd13qc943snahd5s7l67hhvmlqgdq44jk30855pvcnffrhjd2fra2gqny22j4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3760,7 +3770,7 @@
     }
   },
   {
-    "address": "erd1jfnua9264jhfkcdelz2n2r4l5kpj4r4f80zj9t7zh0fkzws95lpsjj6qdt",
+    "address": "erd1z5w9hu0w0ukzhyxhdhkg2e93f4q9mfk07r2rrwvgw3xm04umvagsfz9527",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3770,7 +3780,7 @@
     }
   },
   {
-    "address": "erd1h0zf83eueujcv5xamg4wme0gsev7lj84yjap4lzuarkh3t8qp0rsv3qk6q",
+    "address": "erd1dlnsr7quflvr7umrmt0xms0gcntu37txg3xpngd5mgyr8y3cnh5synwxmg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3780,7 +3790,7 @@
     }
   },
   {
-    "address": "erd10u4r75hs70vean67ct33dz5u7gjrt2ntjuv2mzpymjrygy4gns0q8ymfen",
+    "address": "erd1d9a9p4v6zhhvq0zv0a8wnk4qzw4gf7gzngv46e2dczaj7cds530ql5llrl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3790,7 +3800,7 @@
     }
   },
   {
-    "address": "erd1kkdx6akhew9fsj78040dlj7usjqxwmkqcnnurx9dt0rewhqr8yzq4nuhjm",
+    "address": "erd1mpe32tsq6hjkekwaeh3wu80he5d64gqx0yef4llzcxsswwl4jqxsj6jej5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3800,7 +3810,7 @@
     }
   },
   {
-    "address": "erd1dpg0ajyf8a9k2mvcs09jswsme6fe87wak2fa03e5mpnv8crgvqlsvm4c3v",
+    "address": "erd16p68dejz27hqveulywcmj0lnvj00fgjmsy95cfypcjmdr02ul0kqx6kvu9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3810,7 +3820,7 @@
     }
   },
   {
-    "address": "erd1uvvtxwmrk600duhx9mz90ywlafq2wu74cac4nt8xf8t07k53ws7sv9ktvp",
+    "address": "erd16xnd2q3xhzmy6hygmjezp7lu9qxvm79vcl2g83jfhljqn7qzqlssdvxyvw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3820,7 +3830,7 @@
     }
   },
   {
-    "address": "erd1vrhg68vzhwxutxzutmwwndh33q6848x0mekj9ce3rywtm5l572gswuwzwr",
+    "address": "erd1nhphnttemyz03h9q6elkq3cnza4wg5xd48clnha23v2prawkk40sj35rns",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3830,7 +3840,7 @@
     }
   },
   {
-    "address": "erd162xrwemg8gprm2k2zfmd9ee66qkfc9j5h5ftjunflygnhg22hlrsjjsuv8",
+    "address": "erd1h2qs5zt3f2fxjg4gxuhe6k775x386cr3duzx3ysrvlwycad4wlrsfx5lmz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3840,7 +3850,7 @@
     }
   },
   {
-    "address": "erd1e8wafuqq6p7gukqfxhdym7kpkuq76kud2k5p29khgduh256x60gs8dkzay",
+    "address": "erd1vj96j3vpfp6f3hfk4r0gv404j7t2rgx0wu379eye0ylsahewj9ysuq9yhs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3850,7 +3860,7 @@
     }
   },
   {
-    "address": "erd1866c0edf4qrwex0myefygvwltrdyeaz3ha4txpf37l3ytr5pp64scu90wg",
+    "address": "erd1r8pw72s5gm2d3029e7c7227a8lqc4lqp5l6ssfmwdvv2e65fcguq09kyhv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3860,7 +3870,7 @@
     }
   },
   {
-    "address": "erd1f8shyxnvxr2m3gx85etxrfjlt97m6p3lzrh5f33rpn47juu09stqekutdw",
+    "address": "erd1ak32tzr9gs56zst58wg9tq9d9acjf9aqqamu7a8apjg6wm36az5qkl26lz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3870,7 +3880,7 @@
     }
   },
   {
-    "address": "erd1l84e297thhgm642ds7zw4v3swwuu945783wfeclv2fp9t3h7tj4qh0mt53",
+    "address": "erd1u5cq5teke20dvrq6yrfs64utquyqd6v29zh3s8jsafuf02x6v8wq04cl0a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3880,7 +3890,7 @@
     }
   },
   {
-    "address": "erd1vapushnn667uwpuu74ulfnvwdehvagau54h4qkwuqgpyfemvh5jshzswc0",
+    "address": "erd1mtz80vcf2kdqlh2hd3srsj0gnl6gt5dwn6k23sg459r36naetxvse9m4hp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3890,7 +3900,7 @@
     }
   },
   {
-    "address": "erd1q7avns4e4pz48rplpza7js8fxrfnh6n3q2j0wj2xudque25qkmeswz2n86",
+    "address": "erd1aprr8elq825uwjn4ghzda3yq0jsuvq9xt3as6gk4858mgx4szmnsepj73v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3900,7 +3910,7 @@
     }
   },
   {
-    "address": "erd1jxam2r3xewhg8dhew6c28qrlkeya6c3sju0q0tateqxq5thzt9mskvr6q6",
+    "address": "erd1z4pade6kgr6vcju2t3hga5qd5j3s23d95ehczchdvzzc80yu6gds6fcpl0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3910,7 +3920,7 @@
     }
   },
   {
-    "address": "erd1uzeh8l0cljaaqgpcshy2gemxguz5jtcy3klx0ve0pk9lv7yfl69svj67xa",
+    "address": "erd16dglt9v0qsfam2rsquz3suam5fdrzagp0amk48qplkekcuqvs5pq0c4dju",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3920,7 +3930,7 @@
     }
   },
   {
-    "address": "erd12np98nepz2amm3mrypch364eugxyu8ahc9yrkcf645x8nhqc3xhqng5vug",
+    "address": "erd1fnt6kee582uffrtptmu2t7dkqc6f4ze8kc2mhmat5pyt7fxj3lhq2rxgwa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3930,7 +3940,7 @@
     }
   },
   {
-    "address": "erd1mygpkhqzpsgy6gax5f54frhlwz4d34t0uy2ls3qkfzukhhlv7kequypntc",
+    "address": "erd1y0xvk7t5846wgxaq4lr4mafchyqm4yszgel3z6t0vq7kar5d55qsrtxk88",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3940,7 +3950,7 @@
     }
   },
   {
-    "address": "erd1zm3auj37qyqwpgh464lhsu2luvc6phd5d5384yjt0ljun7d240lqshq536",
+    "address": "erd1tfuts7tcvwvvu4hz3ahavvargfqyr7n2vhnhwxpeapvk6syquqwq2fuz35",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3950,7 +3960,7 @@
     }
   },
   {
-    "address": "erd1lsud746mlws9yg03z7735rnuac8740yatmzrpqmkmf89kde8mtwq5tftum",
+    "address": "erd1sccajw26x5khfk8ydex995gx4t2aq7rdn3alw5064cnly3ec8cvs4rlv8y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3960,7 +3970,7 @@
     }
   },
   {
-    "address": "erd1tvvgaw8jcygeu3c9vwl57l7qtepxxw7w47y7p3j33tdtg4lhwnmsnr4636",
+    "address": "erd1xm0900kx9yd2p7hwcqf7erysrd0hndg0zy4pmsulwqc56c63he0qhhwer4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3970,7 +3980,7 @@
     }
   },
   {
-    "address": "erd1mx2yp58a7aeajqdk65ss4aawtz2g9202p3sws3m6z5vfen2dkqssk4pykw",
+    "address": "erd199xfjcy3ta9cxj9mgh6hncv4wgkxvu3rccu5pdczlcadlynk75rs35z3ls",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3980,7 +3990,7 @@
     }
   },
   {
-    "address": "erd120la665e6wy6z4cgv8dvyhl6ahn24ctm6uv3zaa9j2rg3uk066qqxqnp5e",
+    "address": "erd19khs90azw4rz72e259zyguj7vstr7glc22pcs2tg377dmkd7cj6q72w2z7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -3990,7 +4000,7 @@
     }
   },
   {
-    "address": "erd1y07eg0wdcs32s59fmca76244ljx82mnlslqp2z23nffstgeqrz6sxf7k72",
+    "address": "erd120l6axc0p3y076x4mhkwrt36cdsvulkjz5d5kxtd3ctug05m3n6q8epues",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4000,7 +4010,7 @@
     }
   },
   {
-    "address": "erd1unz286gag6gwyhtknt2aegmzn2whqs92xehlwsmm7mp2a7et2q6q3lkd9v",
+    "address": "erd176lpgme5un7kuvv4t9skej7wd4j02v73mcd9kr9w9wkv9a74e0rqs07v4y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4010,7 +4020,7 @@
     }
   },
   {
-    "address": "erd1etm9a5yv2lsld2pkd2xuzf5yfcp7cvlsm5tvtfcqfpyvyzheqcmqfgvegt",
+    "address": "erd1m30mfgm0lkppkem02tzrpc0k4e6wxeqkxv6l6w2n4vlf0cy5pr6s99y257",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4020,7 +4030,7 @@
     }
   },
   {
-    "address": "erd1j9y9hjqn59xr5c4g6qzemklh8uhxf0t9zg2r0kgx4dagwww6efks9nlsjn",
+    "address": "erd1v5rh2efvmg6qrlpteu7ls3ks3u9z5g2qu4rwt0r09ujuuxlmgr9qfne8j4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4030,7 +4040,7 @@
     }
   },
   {
-    "address": "erd16u4cq9xugv7m9va0zpg7neptt7nre57xl0s0cvn8u37xd5zm4t5sca9smd",
+    "address": "erd15p65sl88ymve556zaldgsnudd33w8pt3kqflyy9ajakz5f2ehxjsegd7pr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4040,7 +4050,7 @@
     }
   },
   {
-    "address": "erd1svrcyx29mkj9w7a8gxs5uw8jnf44cpnmj0ms7hmxftmzt5e3lw0qs6lp7w",
+    "address": "erd1stkxl4rfxtf2yguqgwhxw6fpdd3vkkghdc5zeae9s925l80jf37qt9vymd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4050,7 +4060,7 @@
     }
   },
   {
-    "address": "erd1lfwdyg03rlkwvmak8gkcjr273s2yhjh7s75a7vm7a3kdemamhqmsdysde7",
+    "address": "erd1ntln3964q8k652wc5srswt2f7cmdm0g0ky9uryzytf9lqfs6rc9suykcm6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4060,7 +4070,7 @@
     }
   },
   {
-    "address": "erd1y06yavnsu402v9pl82y8m3uw3h4apuvea6qz8xerfe09cn0khyuqhxnzlf",
+    "address": "erd1pal4tjuejn578jyrcxcgsy7v9yl2npestt9wwa45z29q6zlnlwvs8uqrpq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4070,7 +4080,7 @@
     }
   },
   {
-    "address": "erd1ghu4ldrdusjds8es8s8n6w3cxx4gqujfsrjv8dhvtpeup86n5wxq4fjspv",
+    "address": "erd10mh4aljwljdstfhr3ra9hlwlzfsckxqer7gcd49qk5gfpuvlktpsnxjzs6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4080,7 +4090,7 @@
     }
   },
   {
-    "address": "erd1muse365w57t2knwp7h2yg6p9m3l2wqwuqqv7he5rzp2fnjzy35ds4t8vc9",
+    "address": "erd1fasskjmrnl36zv3z95yls2cc0jmhac4e7z4ueg22wl5hft8gsfvsweu4n2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4090,7 +4100,7 @@
     }
   },
   {
-    "address": "erd17tqcfu3c2p9zd4pxl7gr5ap7f8emj76mdntssvsnt750ztyqxersjnped0",
+    "address": "erd1660399yqnumfdlr5laexyp3ydyg5f6q4yjxh2nea5ld32zuxn9asy6xsnw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4100,7 +4110,7 @@
     }
   },
   {
-    "address": "erd1k6s9fvp64hv6f4ykv2e86h36x5q8uvsv06zq7l0s92pjmk7rxwms5pzyda",
+    "address": "erd1ask6sz728cdme76dgp4fj82jyvkzjp7939j6sqgz0dn6la8hk0wqcml739",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4110,7 +4120,7 @@
     }
   },
   {
-    "address": "erd1cnx8gyt72w7ah4zfr0cwv58q9g2mp8azynvqpq23ggkqj6zplglqr320ng",
+    "address": "erd1eurhm7rtfcz669q80xt9rt7z9c043ygssqwwlzys4umsfl6l0u8sz7r8zl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4120,7 +4130,7 @@
     }
   },
   {
-    "address": "erd1gylg7k0asyt58kceymju6c9t90hevjr428n6jrs53ms7ffq3jx9sja9wpr",
+    "address": "erd1ez90uffpf50lv80ktyngjnwsrr3ahnas633pzfvlxhk6wwqpnvnshrqr8x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4130,7 +4140,7 @@
     }
   },
   {
-    "address": "erd1ewek8vseksd45pgae4gapglvh67kyqcrp7uxljj4qz6lehpwc7cq4c5n0y",
+    "address": "erd1cudjfkhalsr6ssuywfq0fk384luwnvvs3fywnpctmkl6xpmnnrmslwz4lg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4140,7 +4150,7 @@
     }
   },
   {
-    "address": "erd1nq4edhgymhlzxa6qz665w9j8p9mws4d4ckm83fmjpk5kqzyvafvs0p32gv",
+    "address": "erd1rjgg40d5nww075kzg9p6dahy5dtc70j2lww05m7gsdfc9m6muxmqelsf3n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4150,7 +4160,7 @@
     }
   },
   {
-    "address": "erd1z7hvg2jz2zvpzc766fpnketmu3f9aenlv99qlt77z30u2kd8pfaqq8ea3r",
+    "address": "erd1nkyjczguguaccct8vuvyu9j8xahq4vtzxcxtwnwneeh4dz8ux8vqazws4s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4160,7 +4170,7 @@
     }
   },
   {
-    "address": "erd1wuq9gmrdh32sn75xf2lndgv3unv94ml4cf8q9fnst3j3fajgzytqxweel2",
+    "address": "erd1wa0dgqfp3ha5nmr0kzpe75c7tppunm8v5v9ta0sr2d376etahyuqujn2dw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4170,7 +4180,7 @@
     }
   },
   {
-    "address": "erd1gxd8yxfuamh9kcaxr0s8knn5s3ygsymgzgn6qxa5uj53j93r4dps55cv2z",
+    "address": "erd14pmv45k558xgsfnhlpcz9se7ga50lm9u8zznt9n99q5k0kdyjjcqsufp9a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4180,7 +4190,7 @@
     }
   },
   {
-    "address": "erd1dphx5e7nf9xekjz3v0ut90y2xunvaws28xzxdwntgs0rqzvjwefq6fkzds",
+    "address": "erd16avuk6vsjds0h8kpz0aq8gyvfgrndu9z02l5rg4yvckpfr0vr9pqtrtcsl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4190,7 +4200,7 @@
     }
   },
   {
-    "address": "erd1w6u9lw9j97j3xdfe6603c4hrc7rakuz20lkapl4pgmtaya3ptmxqyx5wse",
+    "address": "erd1frf9rydrwvepr92g4xd74n9ux6wn9ej72dmxuk57yd03hlrzhgcqu23p6g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4200,7 +4210,7 @@
     }
   },
   {
-    "address": "erd1h5j3cnwexkanecmefn3s7zycmplj34t3hy2wju3pgz5l7fzqyjlq52fy4e",
+    "address": "erd1fg8wt3qwnfm9kfeywf6ecxn38tntv6vf8pgaansf4eesrxasnvvqx5dnj9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4210,7 +4220,7 @@
     }
   },
   {
-    "address": "erd1qs88qvp94e88ca5k84z64v9p6wtnxxdf7tfevfef9nag6hjzee9stespl2",
+    "address": "erd1jq5sa2vrtpuvac92jdp47mnu34c4q9w7q9mlssgvpmyxcdrt0ngqhs6fzt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4220,7 +4230,7 @@
     }
   },
   {
-    "address": "erd1s4tyz279zrun4a27wxg3x074eyakcvymztumthsm6u5lzk8vmpnq8tp0xv",
+    "address": "erd1eaq3r376fkvpz0mf6h6vpd08cssggmrfelmecjd4xe3p5nlmta3qpt6hp8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4230,7 +4240,7 @@
     }
   },
   {
-    "address": "erd1dp76q3k3rmgmasekgdeulzwp903v90dp3j8u4mc0zwxktmaltuaqx6fyat",
+    "address": "erd1ygqmjt4yfs7fdt96m8ekpv3tna65en9eejntw0cfqjmxcmk9mtcqnlquds",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4240,7 +4250,7 @@
     }
   },
   {
-    "address": "erd1a3j9fgra2q3htv6wvw0nkpe558c7qtfna65vkkvqqmsqcrfj420qawlse3",
+    "address": "erd19f2dw8q4spnkhfpvxskuqge5q29kzftuup83l55ve0t566fym3aq84kmc8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4250,7 +4260,7 @@
     }
   },
   {
-    "address": "erd1mdvnr8pz875nsfalcxukg47pkaf08xu0y8x9y7mlmp3dpy7cvhwsnr38xw",
+    "address": "erd1uf67hgk3u0j46tffy06ru6xwlsxtu3qfy3talaqa2nt2d2mjun3smkuqd2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4260,7 +4270,7 @@
     }
   },
   {
-    "address": "erd18kqjh0zwkfynprfw66tsq7rvz5ts9wvskrvjpxhrcta2nnryzsmsv3jm34",
+    "address": "erd1rty2jnhrnws0a5ytpe2ktw3g2trmjj44fy2spr2kkj8lllm5msuqw5kkjy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4270,7 +4280,7 @@
     }
   },
   {
-    "address": "erd1m27t0gurgekyukrspta9gf9t9vhx8mhwssg7v534kefautv7qycqca4yce",
+    "address": "erd1pyu4f0eu5avny4whukhqxjunclghfewawc6n2hnn3vrpv83cl36sr06pgp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4280,7 +4290,7 @@
     }
   },
   {
-    "address": "erd1vjfxn23qky8dptyqfyv28k35zl0e72n62x5hk7we4u4v72ucsk7qdrlyla",
+    "address": "erd1cnxhvl4n5drtfurkpylmjs09dz9z7xnm8wpnuuuysz5wzpk9cvfqaz6dj7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4290,7 +4300,7 @@
     }
   },
   {
-    "address": "erd18gnqgse3pqegt7gwnlg80h7xcjva07z7y432faq06e5dx5dapfrqjah0uk",
+    "address": "erd19ykn7av0mgcppqmpmc2mkclnatyql5ne23y7xwl634r58hyjl6vs3wx5t7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4300,7 +4310,7 @@
     }
   },
   {
-    "address": "erd17wzq3eczkph5jpuvnha26saufkkc9slnhjr3ykk0me6lmcg3j34s8xq2hu",
+    "address": "erd1a4ecxngfv8cncskpzfmuzyj95k2n00u6tauvks00l6tkl9rua5csjnjf7m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4310,7 +4320,7 @@
     }
   },
   {
-    "address": "erd1egkc6h8m22gqyydzkmst54n0zptg64w5ng27j03f8jkvzuwn5swqjgf4hw",
+    "address": "erd1tn5m5wvfxhdu7xuwl9xmas6nud4d7s03dacjxwmy4xt5tp6c0txsftu807",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4320,7 +4330,7 @@
     }
   },
   {
-    "address": "erd1wuz3nzmqc08xkule8gela0lfg2ewy8mcx0zxev5t3aun2kq7hhdsxze2f6",
+    "address": "erd1vs29fghpyd5rnj5y58732sj0pet9pfd0ad88kpp9fhlem4snkjqqede3ld",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4330,7 +4340,7 @@
     }
   },
   {
-    "address": "erd1hxvyvekthpwmax5kt4445exnvfnfwjge5lk6k776ylhmt02ypywqg3fvam",
+    "address": "erd1vn25g0rysufqcqxqwxk5wmhv7y0cktv28ser3gr5q20cy98r0ttqas44qc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4340,7 +4350,7 @@
     }
   },
   {
-    "address": "erd16qncuw5u9qcf7rjtqhndya8d5nnhwuzvr6ddakr2q4225clm2rns9v5uvy",
+    "address": "erd1460e80jp8x3y6vz8xnu4d7xhqfkk67hdeup2xu7lrlkyuzznxnnsmd7hse",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4350,7 +4360,7 @@
     }
   },
   {
-    "address": "erd1hjn5yj6ptnq2576m3a827uwdyry7tyrh6myznvycew9jjsaduwmqss2gpp",
+    "address": "erd1ju93rfxn23rz5z4fjpqsadm5g905htkddtnwwefhkf9vltycp9pqkex26w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4360,7 +4370,7 @@
     }
   },
   {
-    "address": "erd12ezth6kaqftcwpsmemgxfgsen2shs0scnnsm70uvpqpxkv9cxa6sxpgne5",
+    "address": "erd16hdn988yp59f9xtr87yq4rdknk5lwqtyw6tlt0vaehs2lf3stk5q3klgsv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4370,7 +4380,7 @@
     }
   },
   {
-    "address": "erd1cwf9usyy8ncujam8pq0v75jpxz44a3s7wt9uf4n2axfmw6j6d8vqf9hnzy",
+    "address": "erd1hx3j298xv7rhtw4uewnplr8kpy4t7u680a5qxvmxwqwzmd3kfktq90m9jn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4380,7 +4390,7 @@
     }
   },
   {
-    "address": "erd12vmuhqkhv2cymk3gh5zqw6hmrq6vrshaulnen5hgpm5q28m3wxksj5xe34",
+    "address": "erd1juw32x4e5p8tdqxznt2jy5rrkym5nu3jcsskm2tm4d7xfpphdajsmltnkr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4390,7 +4400,7 @@
     }
   },
   {
-    "address": "erd1djugcty7ep99aulhk2xryne6ecrw7vq4cl3npad5zzuv43wha0tqxh646t",
+    "address": "erd1q9jmdh30rd34dk64ny3v8gld6nnfjamtlm6nn84m8mrm8273vv6sxke3wj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4400,7 +4410,7 @@
     }
   },
   {
-    "address": "erd1lqa0kajkwy02j5mwvtme599ta7g54ym0d57edan3skhsgwsvh0xskvv296",
+    "address": "erd1gu0n7jsnly0um2slzwjg6nc4lcwpn2zztgtzxmfedmjdtz4n59xs7af74w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4410,7 +4420,7 @@
     }
   },
   {
-    "address": "erd1u4z84zj4qud565v6jc9ccjt56xwgqan6zsckfew80mvpum4xlu2qayc8lg",
+    "address": "erd1asamj7q3hagd3k8qa84p2t6cj7t2cdk8s3la6ed3dpu233q9tr5qqlyx20",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4420,7 +4430,7 @@
     }
   },
   {
-    "address": "erd1kfscc7nsqam5005det96z9j7ylp73qdkgn0tx23hwta64tggma3sltn29n",
+    "address": "erd1tzx4e0x95t6scfu6g2k0nfq5l3vhyfxj8l5rwlyf9n6wq9txl3gshm7n3d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4430,7 +4440,7 @@
     }
   },
   {
-    "address": "erd1e4yn86v4m7dkqhnuju3whscn9mfhkx4dzcaduarhvka5gvjlqw3qsz9hm6",
+    "address": "erd1pwxjlrtu607gzfp6cwykwxtv9gsqy35yychuy9darflrujtgqlhqx0lzj5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4440,7 +4450,7 @@
     }
   },
   {
-    "address": "erd1rskxjyqxhdhvngyf9x7mre666xtwms9yw5am70ncc6hqjga4jc9sn6uk07",
+    "address": "erd1cyrgy776naavhlyztys4j8aa28qk5juykl0x63gns85py497z5fqxvsyp4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4450,7 +4460,7 @@
     }
   },
   {
-    "address": "erd1jam7wyzpnyd55gdtn2u7a6lmmyvj3xxhgj8afdud38g8hahc8r2spvc3rr",
+    "address": "erd1ckr3fkc2c9wpyu9dhr4mymxx82s365uyyepyugfqqcefjnx4ahcqfz75yz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4460,7 +4470,7 @@
     }
   },
   {
-    "address": "erd1kzd478fc0p323uy3zmm2yf00xrj68vmdc8yhpv9dv8l2h59658hqzajxnn",
+    "address": "erd1z65t5q0g3fsy5y45quumv8scn3cvluyfdxzcnz43sk45keqgvusqrn4y7n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4470,7 +4480,7 @@
     }
   },
   {
-    "address": "erd1ul0ryqs70eqrha04gg0na5tsepf9xz220cxmnunr6w0pfkg8y2sshxw4xq",
+    "address": "erd1vzfs5hut0dgquvpwx4enss0pp4pucextaeh4nfed8elhzu5lhc4qrusxrg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4480,7 +4490,7 @@
     }
   },
   {
-    "address": "erd1pvwl39rd5ym3gz8lun8hp980rjzgdfs58ugygrndgw34qeaaclxqlej0g4",
+    "address": "erd1ngjn6fud45jlwg8qkkypa2heggz8f9tdxaypngps9236d6pkmdrq3hyzv5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4490,7 +4500,7 @@
     }
   },
   {
-    "address": "erd1853pednvs47vg9tnzkcf4lw74tlvqp5htt96umdk39m6rxkzjtcsxyf3lk",
+    "address": "erd18srh6n30rx36q53y8ej3vqu2ln5nnhhes5myekajrqss4axv0aeq4rl6p0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4500,7 +4510,7 @@
     }
   },
   {
-    "address": "erd1t3c3kegf8fz7patftckgj5e2yj84n86gxq7j2h4ku0l2r4wx6p8szjkyxe",
+    "address": "erd1pz5kxw04c4hvwsuy5xzphrd9eesuk0tn45qazwlpd6np0ve3nk0qrp92pu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4510,7 +4520,7 @@
     }
   },
   {
-    "address": "erd1srdj5vy2elx6pmgfysgany8hhthga7qdzaexd93pcrrnzum3crgqx30kyw",
+    "address": "erd1efam8sjt4nxlvsmlw9msxnyjnkugg76v3tmvcsu66y3fxvgu60xqp70msu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4520,7 +4530,7 @@
     }
   },
   {
-    "address": "erd12pucqllt8s4yqd80l6vmgg70kerfsdz4puu4w4ecx3wq33pdvc9sq0t3uu",
+    "address": "erd17lhftfnu8zeg35kdu595x5fukwt2x2spuul7tcwnr34gq47rxhzsf97l0u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4530,7 +4540,7 @@
     }
   },
   {
-    "address": "erd1w3ghvg7g9p03vmetxleqrmwfzr3rskmm0sln3lwhchez7mqz3q2slj6jaf",
+    "address": "erd1tnd3g04m6slgcevfckj6zrulld2eqgmdvhktfeg40t5rrlr6wlwq0yv8te",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4540,7 +4550,7 @@
     }
   },
   {
-    "address": "erd1gnywehj7wmcfcemj5hhdtcwpx3zf74ppflwllh3v87d6jf8kz7hq5tvkur",
+    "address": "erd1p9ax8659z38606lqtsx66fnl62dmu0rcv0gdhnqh388zsfn9a7esemua9c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4550,7 +4560,7 @@
     }
   },
   {
-    "address": "erd1sxqwj2rytmtlpvzh93lkzea0yntkgxzgpgd3dz2mmghxxaff389q98dyj5",
+    "address": "erd1k6k5ytkfdyruf9pgn0jstrev2ld3ku26ve3cq2ng900wjztsc9vsu82hcd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4560,7 +4570,7 @@
     }
   },
   {
-    "address": "erd1vvpnhx84e2d32k4w5mv35u4l878vdnee06pkuuklmhy6hqd0nheqkh3zz2",
+    "address": "erd1shhgg4wae4tqn63a9pg3cmrnp7hh4ctug407g357p2r7xf2qpmrswwehlg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4570,7 +4580,7 @@
     }
   },
   {
-    "address": "erd1f9t7snxtx8usz78z37tamu6gu7ha5ksclahry2jgd36ummzy49xsczfpnw",
+    "address": "erd12ynyttkvjf0cp2djx7shzpkxl3d5chcw5vjetk3e3n0vd56u5fcsa7kwke",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4580,7 +4590,7 @@
     }
   },
   {
-    "address": "erd1dpr48ev0kqsahukzva0c5gtdpweneq79fdqylmaq5xpa740ydtqsgx2gy2",
+    "address": "erd130hwmcaj4h36cwezfn0fzfn9fyhct5suzuarmgwjzz4psuxmka2q3hpmye",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4590,7 +4600,7 @@
     }
   },
   {
-    "address": "erd1rgrfuujxa77v05f39fx7w77qg4c8ctzq6eca788a0cvpqs3cgkjs5nt9tk",
+    "address": "erd10d9tlx97w7umqfznvr89339ryclp2kyfqts3vseg05r6sklgmh9qhe00nl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4600,7 +4610,7 @@
     }
   },
   {
-    "address": "erd1z0kd9fm64vzls87n8pty9h4ckpnwmn9fm3am4hj8ak23qc9mym8s3hjkl7",
+    "address": "erd1medxzl392hpswg6y5ykflr7crun6lzt3mydkhe23lz3accrhp35swmc0mc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4610,7 +4620,7 @@
     }
   },
   {
-    "address": "erd15t009nn4d5fvsw3h0ckwgft9pzawmy8vmrsrvyjspaamx80hemgsquu2as",
+    "address": "erd1dpxckvtu8gq34dy5mjxgdj7j3k2mmngv78g0p50lh7znsmcyk5gsl032vn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4620,7 +4630,7 @@
     }
   },
   {
-    "address": "erd1gx0mhkxr2yej6rg7uk9pwy2z2fgaq525l55xqerxt4dvzvh08n3qeh5mn4",
+    "address": "erd1tgd68zqfqcjg0fsm3np374pdengd9jpmlcntuvhur6hl9f8n48rq7hl36d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4630,7 +4640,7 @@
     }
   },
   {
-    "address": "erd1p395ulm674l4tljqz4w65m9llj37y0s46vpk6j0hn0a7wxvqyc0sjvn50z",
+    "address": "erd1f4ekngfqnk9mnpgr5m9d6kdl7a22fmxslgvsn7qz4kxh4ynhpx2qd5s3c6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4640,7 +4650,7 @@
     }
   },
   {
-    "address": "erd1t425vra55hqagwscpuvr57nud5eahkpd9t58f63mrxzla6e9muqsrfnvva",
+    "address": "erd1reem7fg5ekqcsskqysetjm5un9u7e49umprcy4z367r0jdn7aqrszc0ywx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4650,7 +4660,7 @@
     }
   },
   {
-    "address": "erd14qk9amcxjjpn5wta6ezqct2nev3hfhwqkjct9gy4nr78thrw89yqwv9y9t",
+    "address": "erd13pjucrkczkl4nv5txe37zcfzju2fxpfzvnsexzhxteqa3lq587gqqwfeqq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4660,7 +4670,7 @@
     }
   },
   {
-    "address": "erd1zmw7n2n5l82l66zhqf3l7a6t0u8nkd240e8rnd6jgtjxu6kh7flsck8su3",
+    "address": "erd1250dhalucf5rmp6jhvlmxt2jhqnak3t5jhuwprmgl7n67pr6furq5sk5jt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4670,7 +4680,7 @@
     }
   },
   {
-    "address": "erd1sulslmguc8mxy0d3w87w24pnwpd4527ew65nefryqy7qt3swn7ys2feyuh",
+    "address": "erd1txqdsmkcr0spx8wfg9lsccaxqg5dj3kr38cmsmc5cc89ze0y66psyfmryw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4680,7 +4690,7 @@
     }
   },
   {
-    "address": "erd1z8pmjp32tu3gjzp7tdvg6j05hccshyzcdnvl00rgyusdlf38djrs7x24j6",
+    "address": "erd1s0qh5cnl09t2cg97ha7lzrqtn88ujp7r0nd3rjjv3vjv0kmr0nnssrc4z3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4690,7 +4700,7 @@
     }
   },
   {
-    "address": "erd13ewm5lmnsc8q3gnplf2mqepd5tcgp7axnvcsudyk5x0pa0v67jjqpanhpj",
+    "address": "erd1nua8h78y9dxzzxm0wd6lkfkvv5y0qr3chn3x905qrepl27x2umfseudvje",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4700,7 +4710,7 @@
     }
   },
   {
-    "address": "erd1s5grt3v72jzapsuven9eh0pm4q4zueftfz6sg75f3ks5ueyg2a0qqmfu08",
+    "address": "erd1mdhugce436kcjra9rgr5kfk3pvymvypn3xvulpyet2x5f8qs0dkser3gz8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4710,7 +4720,7 @@
     }
   },
   {
-    "address": "erd1l92susnk2qnsnple56rdgzq7t8wq40dvz46pqyk7d3t886f9qymqddp4rq",
+    "address": "erd1jg3gkqkllwnxh5rv5mxcaca55zda7mmajvs26nrmeur7aar9nmasl4cqua",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4720,7 +4730,7 @@
     }
   },
   {
-    "address": "erd10scrhjx5zfz2lnwhpvx3cmzfxwd2u5wv93lsqg4l6rjejcfg6ydstlmf79",
+    "address": "erd1l2qme8tzqhx2m4fjp3lu9p079h9rqtxfkjp99qwktp4ep0xeczuqq2syns",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4730,7 +4740,7 @@
     }
   },
   {
-    "address": "erd1hfwxuluw53ymsj6vgp5wnhzp46d55rm46ldv8lpjpt65zj5tfansh3plrk",
+    "address": "erd1kr3hze58er957cmmpg0evq0tgacr94z9tklk68wxc28u3g7jgulsadhpaj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4740,7 +4750,7 @@
     }
   },
   {
-    "address": "erd1y220uxspxljszvncx3hfaum2q6gc956s0tp0tt9rr0q0jak8msxq2sftdc",
+    "address": "erd1alf7jmsqdyl09krm2jvknjfx8h9fmsv6s5ykm4wl20p0gmf52j4sq38xys",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4750,7 +4760,7 @@
     }
   },
   {
-    "address": "erd1mgv0x7kt9fdwt2jd4uf96w6zvgmj0sumfw60fhq7a3mxnz08dfmsug8cd4",
+    "address": "erd1l5mzgye0aljtssedqyyftcdytaghyawrtzltdtkk6hgsv99xyq6qmd9266",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4760,7 +4770,7 @@
     }
   },
   {
-    "address": "erd1e6xd9jw3kje3gcrk6sqx25h3aqfqnrx2ekrfpy7fzefc9gxxzrkqmr29uc",
+    "address": "erd1ddl6nj3esplk9tg4chzkg74809ur6eackzc0t266jdx0xtepzneq7x66d8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4770,7 +4780,7 @@
     }
   },
   {
-    "address": "erd14sxejaa2fljl2wrk7quzxjd39cyn4jwhsk9cf9qq6fcz5a8vne8qc0f54t",
+    "address": "erd1feuefpfzyh3ctwpgsj5usucpy9wpu0k2l3t2rc9d44njmnvge6kqjnet7l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4780,7 +4790,7 @@
     }
   },
   {
-    "address": "erd1ammjdpxh2e3dva6vu0nwvwq3vctm65xyk9dgq85twx27jfdnsvws5lrmj7",
+    "address": "erd1p874lezj4cewrvc7z3qah436dnkydv2gevll2frsrgzm3da5tp5qeykxze",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4790,7 +4800,7 @@
     }
   },
   {
-    "address": "erd1sy5jkrgfz5fsmemxu9vekr84tyh6hu40hvmsuej8ram6ha2hwe6q46r5ft",
+    "address": "erd1tutsuwt84fnmdpw6s3kr0tq92mp3fc34nd6vg05kqtqaajheh2lsa4kg0u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4800,7 +4810,7 @@
     }
   },
   {
-    "address": "erd1hqzf9sfd56mrqf3sd5zdh3w2urclaj9t4736c92suzeqs5euvttql7ze9l",
+    "address": "erd1cs8nj805fx2mlncne45h4499glhj7eyw6hp646cwp9dqnkgvqa3qk3cmla",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4810,7 +4820,7 @@
     }
   },
   {
-    "address": "erd1ennq0f6hhey28ljuurdfcparueu9kup6qd0qpjm8ayvt3zxky0gq0qm3e6",
+    "address": "erd1vf5gpte4ndle6tg0p3w2m0gce750tpcgcmqhh3fqssv374y4klkqr5ykmg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4820,7 +4830,7 @@
     }
   },
   {
-    "address": "erd1zngc0klclqc5u4kwaje5qr7cnfgl230vp8u3ht4g2m6t2ujs3mjsspwl8g",
+    "address": "erd1yhv7l7c2f6f5vdtzlkml797ffh00cpl4s9xn34grqgu78ulwy0gq37xhm9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4830,7 +4840,7 @@
     }
   },
   {
-    "address": "erd1j04sesffd2n70mc7hhvp46ua9s43cdh8x5npa5y0sgqtmcm2lkxsyvwhf4",
+    "address": "erd125wskvh0cjy0qp56c9a7wwpt8td8ra2kewedq75e2vwjrys55dsqn392la",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4840,7 +4850,7 @@
     }
   },
   {
-    "address": "erd18qkv3z2m028r6uuxw6mpta95uj0mzc809t44yuhtgq8p70yn55cq62dk8x",
+    "address": "erd12flntxpq8hh6pme7372qlc766w5ecmchnrspch4rjv7mj9xh830scj0eav",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4850,7 +4860,7 @@
     }
   },
   {
-    "address": "erd10gq7jzfmtqggv0lg5fp75zn8tl44ulcjd0uxyrtuadc49h6ka9cqyvjjk9",
+    "address": "erd155fyd3tss7vaxfdrkl5yu7p3z70jwc5vzsmd50kwvcnt22v236zqzht5u3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4860,7 +4870,7 @@
     }
   },
   {
-    "address": "erd19nmecf84hk8kdsnzus4r482rnrmlv4l46grh0vswtllapy4jps7q0ku6xj",
+    "address": "erd1783a9j6lvnaj86p2fzwl8n3f9635p34mzu9nxr7qtw2vrprqh0vsapjcv4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4870,7 +4880,7 @@
     }
   },
   {
-    "address": "erd1we5t7wuf8ycs4k0ns3j8kcgq4scxnzpas8jklujfu97zyqytxg7svxsdq5",
+    "address": "erd1cv7wf3p8x8m8mfluv59npz24mnrgxfcp80xeweplqjl6k84k7r3qjavhtn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4880,7 +4890,7 @@
     }
   },
   {
-    "address": "erd18mcq900g9x9fh6t4chc3zc3z6fj5l2dpx6x64zqsq0q3jzqmpfaskzpxhw",
+    "address": "erd14kua8wcgfsnd6pzua9x9zql3x4wg9z6580q0wd3gmvk23urnrvfs546j5y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4890,7 +4900,7 @@
     }
   },
   {
-    "address": "erd176u77aulnaxvmav6pyaj6kk0sce44x4yc2p5r8dy4s83gle8u9csjnksem",
+    "address": "erd1unxu65tfccqnlxqzjxenn7agmyudfncwc9mlwclxvm6w64q6xv5s74vlqq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4900,7 +4910,7 @@
     }
   },
   {
-    "address": "erd1mwh4f7v33jza7r6j4scs6elzxmqgeg5exr6nurqq06ly6smghr9s46fqsl",
+    "address": "erd16g34sw8vp07fj4atfyfjmx4gt44sq7lcw2dlfq8ukewfzs0fcccsnjel3s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4910,7 +4920,7 @@
     }
   },
   {
-    "address": "erd1vap7mewclf5vuh5tdea6j97v0682ghh7407fffq84ww9qzsh3ygs03v9x9",
+    "address": "erd16gkfkeew7f7zk2su5fzvkct9en923csc5f9d8f0z8dj4sgffz3tsynstw6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4920,7 +4930,7 @@
     }
   },
   {
-    "address": "erd1c4967gpxqvm3qc3aykt8raq3qrhwp3kl08tstpc48wt4qsrc3qcsgyxnng",
+    "address": "erd1ufff00ux9yz4dmms9rvnn4nqwjhpp6fc24fgs2n3z4cv3a4th7eqla470t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4930,7 +4940,7 @@
     }
   },
   {
-    "address": "erd1vgk63d27uz4wf5j9ace854y8pk50057p2vvrgs5q94mpd05x02ssqkmduc",
+    "address": "erd1n7rme6hthxnf3sg76gd5a2gwy06weefll6ly3g2ukj27h7063dus9pjndn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4940,7 +4950,7 @@
     }
   },
   {
-    "address": "erd1l65j8v0whp37rnj9gej8hclr4upp2fk86zmyaz7e2tkcque4hjdqfhn755",
+    "address": "erd15jy7nc33dx5k37qfeasx2dyxdrzsgl57w8z0exxpxwady38kgrwqa7jy2p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4950,7 +4960,7 @@
     }
   },
   {
-    "address": "erd1mw6e4cc5l5nlt97jkkqfycdlx5l83c7322qsjckv36ewmt5c739qkkue7p",
+    "address": "erd1sra9t00nx6s2m9hdrk9ufwu6mm2lgv69lhg8vqtcw385u3kv45nsamw3n6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4960,7 +4970,7 @@
     }
   },
   {
-    "address": "erd1crmhug72ekaz582vz590yz2s9z9qa2qz73vpas8jl9wqetheh75q2tt93c",
+    "address": "erd1xwg7f5jlmlg7f5pptmwgrfmefvwm9028wzts6wnf6dme5av835lqvvnk9a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4970,7 +4980,7 @@
     }
   },
   {
-    "address": "erd1nu7qw80dd6v2g73e45ec7gu8kna4ghpucjhalfhrw0x2aysxrkvsw2lxqv",
+    "address": "erd1zx2yhr4d0nmq7eqvw52t7ey7scah463l80eqk3q6w5ru2wm204usxn6443",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4980,7 +4990,7 @@
     }
   },
   {
-    "address": "erd1hv907p9wwwz3ucdng7h273j0ffmzuc9yqcqh57xzf4kqeale82eq40xu46",
+    "address": "erd1ppc0zukz4h7k46vxltw47984xmzee4jegmy7u7nv9zt2g03w4vws7x3js3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -4990,7 +5000,7 @@
     }
   },
   {
-    "address": "erd1n6fts2tntvxff0ezm3x7spqd6j4lmg52g53sq3z3euzag9jzp2fqwzt8p6",
+    "address": "erd100dt9tfex6zajcnppaswqn9pfxl4ga9axf7ag3seukuhkpee9p2qeu4skx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5000,7 +5010,7 @@
     }
   },
   {
-    "address": "erd1e0vzgfhyxr4zmuu34zr3lav55ykda0uhnqyt2638xavjjpxfangqmtcj6v",
+    "address": "erd15lzhnpv7xl0cf0nuxkzz9tpm0acpnu8wf7qt7y4f06svayel886s8403pn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5010,7 +5020,7 @@
     }
   },
   {
-    "address": "erd1htq5lx26ayqx9a2ha3fu3la6rqpav59h7jj4kynxdjh2wnkfvhhqptu5w8",
+    "address": "erd1z0yp73gjrje74fdl8g0p88shrx4tqxy43qxhnufq8msrv97tlwqshjvzsc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5020,7 +5030,7 @@
     }
   },
   {
-    "address": "erd18wmwnsspus8ftuchmeq90jvh8e8tmnfmusv5z3cuarnqu4fhu9uqaka5xm",
+    "address": "erd1w30t8484r9pjd6cvl70gudgcn332dlhnd0nmhdwumgfn5nv5tp2qkzcxjs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5030,7 +5040,7 @@
     }
   },
   {
-    "address": "erd12gxqjrs4appksenj5yd2y2aadlv37e6kq6sgw3nl082azasyyekqmcugms",
+    "address": "erd16uqljwxy26l6xhq2x7fg60e4tx4xgj8zj3nzrf78l8cnek5kk8hsf3z6kn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5040,7 +5050,7 @@
     }
   },
   {
-    "address": "erd1al6gd7c4gl5r8ae059ah6h3swunuqkcak3nghn82gfhwmmll9d6svra05n",
+    "address": "erd10ngsrvzg8v87597de28hxzfqpandtd8h8wl8p5l0u0q4rk4yh6uqx0aw40",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5050,7 +5060,7 @@
     }
   },
   {
-    "address": "erd13pnk2e5thtdsuz482uahue70n8g2s5f6z5djg5lj0v4rny2n7v5qztrvm6",
+    "address": "erd1rcd3qncyg0ktyadltzj9wanf6xtv99l22p74t389yv4ut4h5tk8sssxgvt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5060,7 +5070,7 @@
     }
   },
   {
-    "address": "erd1mlnrzy36x2lx796veawe2tuahp9xyd0p64pua02jg8np9hz9jhuqgh8znz",
+    "address": "erd1ule2g7sxa2arlstfmg2xvzdmu7k0pv9ff892uvqch869550g6vzqv54z48",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5070,7 +5080,7 @@
     }
   },
   {
-    "address": "erd1d8g76fpqwcll7as5a7hp5yrpwfwvh7vmk743le54kn4d7569h7qq4kx9sf",
+    "address": "erd1wswz4u4nnekwzu8xjq9vu28vxe2d0a9htt0ehsr7jmwte27nq97skx2029",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5080,7 +5090,7 @@
     }
   },
   {
-    "address": "erd1g426hagsnfrjw6ruafyutrnt8sea7nwv4z8agynkazgqqcz9wgks5czja9",
+    "address": "erd1evuzxgsejgauqv3ct73dvk82t6qk2j3wjp8vafdtffxpzdq7r3dscwqap8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5090,7 +5100,7 @@
     }
   },
   {
-    "address": "erd1yz22ke8t45scjvhxmdx0k75zlsse56l2rjljt8x9g6ns0fr3f4qqccat85",
+    "address": "erd1r5d0u0fpzjc7uzlkt0vkuav750xst64dpzgtvnm3d6xs6cxclpmsf5nq8n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5100,7 +5110,7 @@
     }
   },
   {
-    "address": "erd1n6rm7pg0qzxweyma2ewvu8dt3k7qgpssfchk3amdp3wjl0jx0leq09qm8r",
+    "address": "erd172u4w7kxntskwsf2a6wfnn27sr9534cv7mqnezypvm6zz654e5ns44nlf4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5110,7 +5120,7 @@
     }
   },
   {
-    "address": "erd1xuwh8hz9y80ga0tzmz89d0kx6smtltg6ju6gwvzl8km4qtcjxztqnhsyv2",
+    "address": "erd10qjpfaq4fq050238r6uxku2xcts7c9l09n7y9n2gn692l7nf5xvs0apgme",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5120,7 +5130,7 @@
     }
   },
   {
-    "address": "erd1uf469q5m9h8hq89u7w827nr2arfa7w70438mlgxmnq3fzf6wfvfq4tsl4k",
+    "address": "erd17tmlxyxhply3frzx6nkr5k7zthxa6tzl7tqnmtc7uk54j7zjs5aqngkmhu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5130,7 +5140,7 @@
     }
   },
   {
-    "address": "erd1yeny24rg8wne4ekgal4s2tqeaz0rnlct5wt0089x4skpep3e9y9q0c4az6",
+    "address": "erd1kdg5cf8mmywh7hxmgr4lanpwzdywawevnljvpej6djp4rhe2s2uswnmw03",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5140,7 +5150,7 @@
     }
   },
   {
-    "address": "erd17ltp0ln3xauw0ndtdu9463tum2cttgwmdafjylg25jkut9svxs6qy0dyju",
+    "address": "erd1ydf2xrdnv29u2svmcgvx89tf22ccnt52feyuw4e97tg2xfj3ylpqe8jfdf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5150,7 +5160,7 @@
     }
   },
   {
-    "address": "erd1ygwue0vcn2gxpj7eg6nawfsjauvky37u93akpkrj6ztsrfr3pvkqq6dr60",
+    "address": "erd1fxtxp8jr7zxtap8lh5al6zvvrvagl0h5z5nv9af4faygfwtdkfhsjzjnus",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5160,7 +5170,7 @@
     }
   },
   {
-    "address": "erd137vvzrmcfadegkh9tqcl2w3hg2qd2hg83e63cj8d6es706jswl9spjhcts",
+    "address": "erd1kjgzwsxdhnt7ve98ww5qc9hagvp0khxz63pruhvaswet8ya8e4jqzft8yt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5170,7 +5180,7 @@
     }
   },
   {
-    "address": "erd1gkj8w9pc2dya4t4z7xmpvnc5zrgzrahtkcnrh4eeul96kzvmk4jqn7wuvt",
+    "address": "erd1rgk39sw0yzmu8aqrmdq0we3typt8qv9tmccw4c03dvve38rtgpxqu6kt4m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5180,7 +5190,7 @@
     }
   },
   {
-    "address": "erd17dmx0tx3y83zj2cn78rjjujzvucd6ts6l0run6qnvy8q65q3erkqv6j3nn",
+    "address": "erd1ql5dylah2lg72nv2qlkvuyh5c2g00dxhsjw8ynwfuskmzqmvs8jqwpxur6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5190,7 +5200,7 @@
     }
   },
   {
-    "address": "erd15m23z03er4dq8jcvcfuzrt5zlrmtglwedw2wsufvnr0jcqe0tujqj7h7u4",
+    "address": "erd16rcyztlh4qw8dyf2wfx2nx4ehst3xtnmlsq8qtm2wapkj64xpjjqxvqrkx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5200,7 +5210,7 @@
     }
   },
   {
-    "address": "erd1syd4qlllphajtpjdgywccfdtz4ksd8hm9glmp4qmg4lfhmge540sjqkm0w",
+    "address": "erd139ahjzj5k0x8fz8l7arfg87d7wqfvk9uyavs0ppjyunhy07p9kysr55twm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5210,7 +5220,7 @@
     }
   },
   {
-    "address": "erd1sv9d222g4a4t22weza7n5m852lahuqswp7lk8e6mpfcfmrvddwcqkc5rq2",
+    "address": "erd1nv33npumvhkjdhc4s2czz6vsqt8vhdysrfhyajs7rllfnyd0h72seqp6ec",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5220,7 +5230,7 @@
     }
   },
   {
-    "address": "erd15u9rnvfuyuvaqwl32hqqdet9f0scglrj5rqsr6fy9rgw4chj9vrs2yxhgm",
+    "address": "erd12mstwnp5k6p9wu7w0wcpam9wxfnrhvvdc3k7af8sf4cvzv74q99sw3st36",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5230,7 +5240,7 @@
     }
   },
   {
-    "address": "erd1v8s728n08dhykye53zvu9akzhf43vrwvyetphkslegr4rd30ltmq877d7v",
+    "address": "erd1682p8gctmxk2mkuqwq4q7u53lny67s5eppugx9dzcnkstfqg7mjq8p00hv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5240,7 +5250,7 @@
     }
   },
   {
-    "address": "erd1auuws6a43age8d39p73cn894ktwc9gu8mw4mjeru8h5737dtwmzqlctp98",
+    "address": "erd1ksgvke5dyk8xsqx7tdd593r9xq2g79hk6yamyuhlaasyy82pcxvq8qyc72",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5250,7 +5260,7 @@
     }
   },
   {
-    "address": "erd153jmk0230wv8kkqz26j2t77m46u49a8p965c266wt7snwpfluusq2lzfzs",
+    "address": "erd1my5qj2xj04yk6vhfcft0xrwkpw2cxx2d03qxdzjc9sslus09ke6sxhzftn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5260,7 +5270,7 @@
     }
   },
   {
-    "address": "erd1ysv85urh5tpy2qd0tjk93e3j6cd9h92awc287kyefkyj3awmrf3ql9np45",
+    "address": "erd1zsurr3z8uzy5lmflc5h7rjajmdj487ajja9pj4p8ryx9dl0755pswyfer6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5270,7 +5280,7 @@
     }
   },
   {
-    "address": "erd1urt3ryl7hzpt8y0cvp0nmt6f3tlutwnxyf6z388fdkxlmnnkl8kqsw6r27",
+    "address": "erd1fgn7hxz86hsz60x9767vctch572tzrynwpjspsz8tkr6teffhk5qjf5acq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5280,7 +5290,7 @@
     }
   },
   {
-    "address": "erd1xf4j5ua63qj0zhsd9dpza3sww5g3al78el4ks7vrnlqyesr8gqjqge9ech",
+    "address": "erd1mhxlat3gdglqzxlypaxjgvhmmkvkcrvugv4djpmaxlc73zfsle9sj2twth",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5290,7 +5300,7 @@
     }
   },
   {
-    "address": "erd1k8tjskculh4s8287hjks7qsaanwtknda55vgkpm006u9cemlk9uqlrk32p",
+    "address": "erd1t9xjwr3hk2mcjfkf7nym0cnky3jayqg3m0zacxxwdcudnep9230s3uusrm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5300,7 +5310,7 @@
     }
   },
   {
-    "address": "erd1h48jhjmcefhh4lnarewc5cnhrvl0fg979ywvrddnhkwjw2cgd2hqxku9zg",
+    "address": "erd1hg95q77eg56ucu7chfs2dylr2ww8k2n3pfdrq9lldrmlpfu89gys02a86g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5310,7 +5320,7 @@
     }
   },
   {
-    "address": "erd1ujd4uawvtnlmvkstzt7ckzger9088etz305f33z48nfflaer8d6qmkvsmq",
+    "address": "erd1g0l5uqnq6ezvqr7t2lxtdhr8cadx6hh8edursg2cdlgxw9w9lues7lu76r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5320,7 +5330,7 @@
     }
   },
   {
-    "address": "erd1mqpt5hsjmzqthh6t6gg6kvllyrmhu2d2wjpvfa8armr97lrcn2cqpyhtcz",
+    "address": "erd1qwf6tl78chlpxaechk0p6c3r0uu9wz3sa0wjezdutudnwhg5ggwssrm4cq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5330,7 +5340,7 @@
     }
   },
   {
-    "address": "erd1mdr7sapn00qxccugd2fj46p735putk3vlv834fa7uec2nev74d6q3wkg5p",
+    "address": "erd1pk2tv04dajw2fpyzwa63rkcp02g69y7q75w6g8y9dm5hanlf5g6qvwtfkw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5340,7 +5350,7 @@
     }
   },
   {
-    "address": "erd1mkcr9slxzs37l69ck9c2znly43p6pm9crnjml425u9drh53rqncqayc22l",
+    "address": "erd1vug6uh6tkfs2ak2rwfkwm82dg5e2lx0v9ehm46y4zl73x45knkls3k7ntl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5350,7 +5360,7 @@
     }
   },
   {
-    "address": "erd1pqtzezy3nmc05z2ug8pzhytaty2kjrhpqqt4f8j5h9g4vy36decsrqjvxv",
+    "address": "erd1r5h50nv2y575mkm4hugx2gtjv73rf6rst9lascrvwlm6vakyzuvqffn7p2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5360,7 +5370,7 @@
     }
   },
   {
-    "address": "erd1f8mrj8n0dx6ea9a9h4uj58y5sfh7wxm623a9a2k4umyknx0225cqqc7cle",
+    "address": "erd1lalkcrlxsefmdlvu5m9j6h8cdpuaa2rkutqhupgdyfpyuj3ma8rqp5d9u3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5370,7 +5380,7 @@
     }
   },
   {
-    "address": "erd1gxrlw6xxa0nwgztchtfqzjhgj3qfhvv2zhmkc38d70mpjan5p2ksgruhc5",
+    "address": "erd1zymh0hn6j29srq7gtgcjlll5xg2qt2s8n2tx8tgkn05sxuyd0wsq2guelc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5380,7 +5390,7 @@
     }
   },
   {
-    "address": "erd192y266axkwxet5sv77t5e8mk2a6upherprwawhxwftrqhnd76mcs87pfpk",
+    "address": "erd1vg24zlpnzjkmq6tj2zdx7ndznqyq3tpdkca0hhhxasqxg8u4tpsqflj5m0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5390,7 +5400,7 @@
     }
   },
   {
-    "address": "erd1k6u7qxl0r83sy5x4zd2jwxcmt63p2pqvg3kpl3r5rqy9436vntcss52pz3",
+    "address": "erd1klllclx9u3syehrjw5r70fpff90ufyuvfvx5e2h8h66urhw8gedscasu4q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5400,7 +5410,7 @@
     }
   },
   {
-    "address": "erd15murxgvqzppzpmxlmxqyp6zth35wga7xu03gn0jnz8aepvgvu52q0stvu4",
+    "address": "erd1zyj0pfq0z9gqw7hzf08704zr5kryltqf6n7g0ae3x3sv9x7ttsls8ph3yy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5410,7 +5420,7 @@
     }
   },
   {
-    "address": "erd1f06sza85qnh2s2atcskan8m88m6w7mw0zdp7tmr370fl8a7sly4sfsj28w",
+    "address": "erd1p8v9ndx2rjy4e9ehsqxuppggy074ufv0tqv673f9zmt48js6y05q863qpk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5420,7 +5430,7 @@
     }
   },
   {
-    "address": "erd1ry3e9vajn86kja76p0sl7k4ytwxjrw6tcdpnp4r7svk62qft77ys8r2e7q",
+    "address": "erd1cdw5w3mf8maqy4hagthtm7z6ust8n8e6r3xr5ghmjpyx3egndekse9g84x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5430,7 +5440,7 @@
     }
   },
   {
-    "address": "erd1du5e5t87f568crp76c68hrqh7skp67seauqdg4q208czyqjvmzxshfmqdf",
+    "address": "erd19374lhmuy4ajn4l0f3u6e966ll2ruc5afutn9467vuh79v0wcy2q28d372",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5440,7 +5450,7 @@
     }
   },
   {
-    "address": "erd1a0gwxxmj2kkg3a62978eeanyjhat3syv36xfh4ftx9v88g0cw8nqf4482g",
+    "address": "erd1dhywc5stjzmvcrvm03ajv9gzdt4tr4jjwr6mdve6wlvf5twqmq2q97fppg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5450,7 +5460,7 @@
     }
   },
   {
-    "address": "erd1nxzrhk93wttjr7ejldldp5dxqh7u376yjjw7mld4aq9ydyakrsuqs0nj2v",
+    "address": "erd1qwcc3yy35kscr7qa0ww3jxuukd6dnxfkk8cjkatrmllrauzusrws2vlghy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5460,7 +5470,7 @@
     }
   },
   {
-    "address": "erd19ktgynhqtx56vjh9uf09j7acpazcd27tk35sl72hyw6e2d572pqsl2t6hr",
+    "address": "erd1mgnrgqmkwxlccu3w3ay422ralwvlqjr2l8fus69u6lxq8kgmyrss53txsn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5470,7 +5480,7 @@
     }
   },
   {
-    "address": "erd1g3ff35mseka2234gst4zkcxc2kw4raywf4vvk8f70slnksdyc8pq64zcq7",
+    "address": "erd1lnvpu730ckgna4ns5smldaheu7swmt2r7deyz0l7a7yz4ryarf5q7leljj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5480,7 +5490,7 @@
     }
   },
   {
-    "address": "erd16ej64m5wja7te5zeq9prxfpce3n0c6mu5rgt34x3v494c3rum5lsqh94mc",
+    "address": "erd19kef8pwyafxxyc6a7gxqxf9ehjkqrpt5sr7msms253yyr5crjeyq5lwkc7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5490,7 +5500,7 @@
     }
   },
   {
-    "address": "erd1q4mlmlxfrc5h2gznv0h33jq4hz94pl8elntlwuvcpp3lz98nfdwq5rh6jm",
+    "address": "erd1j396umvp2j9k7w3rqy3hey39xl7fqlmdy5mdyuvq9myjud3t2das2mdz33",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5500,7 +5510,7 @@
     }
   },
   {
-    "address": "erd1w2l29p4g5jzhdmee6y4xtf6cls0mqj44uj7qtdmpqd6srseg7ltqvx82w0",
+    "address": "erd1209y9atvyu9aux4y9mmhxlsacgxvr0453rnsupu4sssqdtav0zsq9z9qec",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5510,7 +5520,7 @@
     }
   },
   {
-    "address": "erd1rqj2e4dvk50x537a2s3kzgeukyupnur53ct0ldr8w2ycyzgn5ukqj7uz9g",
+    "address": "erd1ehwc2jpmctqamt7lma83yw7agz5hpfezg296rnfp763pntf9028q83l0zm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5520,7 +5530,7 @@
     }
   },
   {
-    "address": "erd1cd9vgwlmrsrj99ps75elqafeknhd7qsggcxwsvy4esx0nusayujsznatld",
+    "address": "erd1kk4qq7ln05nrlnql9w9rmeuxj9ltghazzgnsn5263cj5unuj7tsq64rngv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5530,7 +5540,7 @@
     }
   },
   {
-    "address": "erd1hsj7j0n7ysv5mr22q42txwekat2epdyq35uc6jztzcjsjuq4zlfsyzxhqj",
+    "address": "erd14njffw38rheqwtgl9mc329mpjrkx8rq5lphe0yknap5295gv5haskvrjwp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5540,7 +5550,7 @@
     }
   },
   {
-    "address": "erd1u7q5gpymn3jmjyhrvtpwh29l0sc7df0de7vympe9gu9t56lrg4aq7m0rqh",
+    "address": "erd1tehsahfvcg2zhs70w72q9fqwns64uekjlku0vp3spl8exfnh29yszgk5q7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5550,7 +5560,7 @@
     }
   },
   {
-    "address": "erd19z6yh465a34wc5lefdfzztcm85fd84usme7wfnhpzpqjju64ydtsd2snej",
+    "address": "erd1fmxpgjf89n09e6r6llvmmr093fyms2ykyx9g26jdlv05nlteluaqpxj7ea",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5560,7 +5570,7 @@
     }
   },
   {
-    "address": "erd1fpqgtk0rf36zzxascre9qrzyff32gn4zty0drq4kre8egpwm9j5q2pg6d8",
+    "address": "erd1xkz06d8v0l8rqqa9rdz2pcr0wpgwld0acecucmlaugk8rpfufzuquekyqf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5570,7 +5580,7 @@
     }
   },
   {
-    "address": "erd1sa6l8urwav7nm7wvkpwrw3fque5vg2ln9rch2ma7wcjg36045jhqladv0q",
+    "address": "erd1fkfm7jxec5lsse57zt4592z3qdc8d760aegsp7n22he0rfnk2d9qcn02c0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5580,7 +5590,7 @@
     }
   },
   {
-    "address": "erd1p882qnh8ejnnpazggnt9xnq25yaguahtytlepw4wgcx0npxsaw5qe4mtu9",
+    "address": "erd1esgu4uq9xl3exqqf2yty6fa98ww7ek9xqvs76m0sapq8f8xs3n5qmjzzzg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5590,7 +5600,7 @@
     }
   },
   {
-    "address": "erd1wze3rrukklre25zcazv4uyvg77ydkndj3ulh90zz8gxxp0suy6mqweduy7",
+    "address": "erd1k4umzfy3e4fhe04uteyhz7usmx95qxcmvylxwmt4z33updjfwsys5ussez",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5600,7 +5610,7 @@
     }
   },
   {
-    "address": "erd1rjntjtn4ur7asuu2w3aeg0xgqu79us0tlze7624dgkkxwxesujxsvshpkv",
+    "address": "erd10z4xcvsuesk3gf6cv24v5fkd0dy2hht3agvhula38fr8xwuxahzqnarpef",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5610,7 +5620,7 @@
     }
   },
   {
-    "address": "erd19hkjn5fuvfjhnl6uxahm4x6w0mnan8reepdukcx4yfv56cqp7ffqlyw8v8",
+    "address": "erd1rv46xyp7r594v9s85mly7lr0y7klfll4yhpapk23f0psu00xujyqqcqyan",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5620,7 +5630,7 @@
     }
   },
   {
-    "address": "erd1d5lf54rzyadxtykshzrm0893ndy6elza7jqap6mugfaj77m6x5cqz0wga3",
+    "address": "erd17rke9d9vv28wtxn3atrszsn40rdwrwkaze8qt5nvzezgllh87pasynvml7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5630,7 +5640,7 @@
     }
   },
   {
-    "address": "erd1vggkmp2vdydslfjhewsvtxueuaz5x8nm94n2az2nzv4z0mn36djsgw57a3",
+    "address": "erd1dx8fkp5glrfezapm09uvsdfxd9sdpn0nkgzd4h0mxjvzs8z38unsq9q0fx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5640,7 +5650,7 @@
     }
   },
   {
-    "address": "erd18psjtn0zuyauscsdqquwc8s8hpt8c7vz9emw8vn92mujgr37mytqju5vgn",
+    "address": "erd1exqm9vjxdv328jhcak40h7plt3k6mqkeahwrkdqhg9pt0x4368msxfg09z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5650,7 +5660,7 @@
     }
   },
   {
-    "address": "erd1p60yh2l34eze9jlw3jx5alrcwjqalymv3sy382v4v0ttytc3us0s3ascq7",
+    "address": "erd14lgtnnjrr8gdawwtsq3pqhde8gm25qa73w0rthzflp95l6r9yetqykm0x3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5660,7 +5670,7 @@
     }
   },
   {
-    "address": "erd12s3p2cpfw2ymqxq4w4qv2ah3v8wgpthdh2stfcuhwle469jp77wqkp4wgd",
+    "address": "erd1w98q70v795kuu7lwqnle36est9cjmkesx22kap03d5dcf4knu3mswpkqr9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5670,7 +5680,7 @@
     }
   },
   {
-    "address": "erd1wl8u408jcajkwgum9479dvz5963579lv769x5nnk0r984nwkvxcqaz9std",
+    "address": "erd1llupu5ce0h4tdajwkvygng50dqx6e7jhn0rr4lvsg0lu5h7nz3qq9rsavx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5680,7 +5690,7 @@
     }
   },
   {
-    "address": "erd158dp6jyt7wq8llnjd7zq9jun9neqkq7d23ass0h7upj5x47ldy3qtzlael",
+    "address": "erd1vykgxvdmnauf52fhev2cj2vzyyy22ww76gsan08p8a68l5vw65gq9k90u8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5690,7 +5700,7 @@
     }
   },
   {
-    "address": "erd1pvulqvfwnxwhamgsr9xtl4egcje9c2ga96rqp9l5zqtuvzspt7eqd7sp79",
+    "address": "erd196lx0gpfau4n7x4wryp8eerpw30x2j70qkdftdmhxsp42rnz6kns4ldcl6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5700,7 +5710,7 @@
     }
   },
   {
-    "address": "erd14q2mymxpl930dslpl8cmzgc6kzy79v6xtupr9nx360kpenpqrglsh0tgpv",
+    "address": "erd19wam34hmvthvygu2k08rr30tnpctwev27thm68t6tnfkkr0n0f9qpyeq9f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5710,7 +5720,7 @@
     }
   },
   {
-    "address": "erd1ph32aem5v4eeuc8uxwrmv0mma0lcj6z68amzk9plen6gzgqtp3nser85ud",
+    "address": "erd148wlecj942prcqmu7x9svyp389vrcr8h6d93z5a07gfwf0tdejtq83mppe",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5720,7 +5730,7 @@
     }
   },
   {
-    "address": "erd130eh2dsjkdkd2px707f7r9mllzpzymujp0uhjnrq5gujuqrlujkq568aa0",
+    "address": "erd16ppw9uef4wuxajxy00yf43gcxqs9z30jysgl9vmjkj00cf6kvlvqv2cax5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5730,7 +5740,7 @@
     }
   },
   {
-    "address": "erd1cmwgpafgupprdfykqcuyr0vusm5s497uq7ne0zhvafe0pfeka9vs38td8p",
+    "address": "erd1yt26u3s5lhsr27jgrfynwhvsqjas7h63nsn5670tjh688flwyy8qe3ads5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5740,7 +5750,7 @@
     }
   },
   {
-    "address": "erd1f00tn39tv758jhafwgzcukvp55dunc32uqhpkfrqzeg2352yjessy6dq97",
+    "address": "erd1f2xehp5km8w8ep5vrwf6w8r5p78mfn3p6uxxm0sk5ytq87jslxgq6yf5cw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5750,7 +5760,7 @@
     }
   },
   {
-    "address": "erd1haf05p2agk5v6ldg6ewj40patskut43j0zkpwrht722n7kgdgjfsc33skq",
+    "address": "erd1hlqf3qcglvfdx6vrsf002wu2lr5w2gmujn8sx8mlc2kvx7qs79hqfsleya",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5760,7 +5770,7 @@
     }
   },
   {
-    "address": "erd1nxl6uhk0wvcfjsmtsvgfe9t6m5tspnghtergypvmzr6c949ekz7sjk65qy",
+    "address": "erd1ges82zjslp7y4md49evatu3d6uwadz3yutk0gjs89h9sg9smqr2qw897uu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5770,7 +5780,7 @@
     }
   },
   {
-    "address": "erd1x25ypgw9jk0ra74dgd7sy63s2rgr2j7x94ugh43ycx8gt7aq4s5s7ujlem",
+    "address": "erd1hjvvr73uc6ly4xc0cgt9hhe3uv3c3t3v0yzywnyl3mxgsr9925zqhtlg5r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5780,7 +5790,7 @@
     }
   },
   {
-    "address": "erd13cllj30hwzrdkfn5x3ffx2ysnjr38y2aa4y93u9v0kuxdkvu348q4m9dmd",
+    "address": "erd1xfg9stdc99ahsy6j2cpm409wxqjef40zrtsty8d2qagksum9s9lq0mpxet",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5790,7 +5800,7 @@
     }
   },
   {
-    "address": "erd1v8qvf98uc5u8qxyvgsqynm54s4nd0a9r5n4vac9tpfe0zmjheeust0u4wc",
+    "address": "erd14kw62nx9sn5cjllet99vvwdtnmxsalnyjesk43q88nzz9h7ewu6suam7v3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5800,7 +5810,7 @@
     }
   },
   {
-    "address": "erd1hpf6qhq7a6f7xjkue7gslrf9jyw0xhk8cdqjpfvfns0fnlndcw3qj7gqsx",
+    "address": "erd1p4geteje9sm2vah3axffkv7fh74ykeg8ye9lzfv9h6spe3ugttzqywksnv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5810,7 +5820,7 @@
     }
   },
   {
-    "address": "erd1cpf48zrvjx6cndxvgkkvqpnafvrn9vghtfq36v9g0xpq6kf5k92qv6gzkc",
+    "address": "erd13zhjchexul4xyxmv8z7r3cehuqfhwv4fanmvtuk6vuzwcjelrahqsavur6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5820,7 +5830,7 @@
     }
   },
   {
-    "address": "erd1vscne3y3kc2d7v94z3rthpum3a45j9t28z52uzmrlkgcjzg8fldqvxsask",
+    "address": "erd1g303g39uuqjuggz2tsgnz6t0uvys9kltfqlqzgyg0uggghv2kw2s4wpqnr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5830,7 +5840,7 @@
     }
   },
   {
-    "address": "erd1svgggl0zx7cfars47zjahrcqew3gpxht6hgav8yw05f3w353dujszujc9k",
+    "address": "erd1mggcymknwy3zvl9e5af9egry5n4l3pehfrvv5pv7heepp53gay3se8uq8l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5840,7 +5850,7 @@
     }
   },
   {
-    "address": "erd1xlyaueh7n6x8zwxxvptx7p7wpmhejfclh4g7t2m0fxmnw744ktaql4ddr8",
+    "address": "erd1r64cmqunz4ynfqmdhlmkzemru03p8etpxmazmh2vamazkvynw36qjgrfsa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5850,7 +5860,7 @@
     }
   },
   {
-    "address": "erd18ja29c0yle8mz26f7emcq9tfz8urc9z4pnp2umf6ylcljd55edkqj2zpu7",
+    "address": "erd1u9ftyw5arqan5wr3475ddg55alankwc23al7ptpejlxq7scjjazqzyae5w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5860,7 +5870,7 @@
     }
   },
   {
-    "address": "erd1mgan20hlmv0z8n04adhv3ujvgpu0pwhvad9zatytvfpk7dgx39lqmddu8z",
+    "address": "erd1369ctztq45a9ulfv85s900dytej3k54e2gjt7x6ku0nvxtgldz9q8j9fzv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5870,7 +5880,7 @@
     }
   },
   {
-    "address": "erd1agje2atfujqvj49lwrkq8n5zmxkg935tf894xr0vzdceew2svfesul4jac",
+    "address": "erd1jkqjntdv5xktl9tewaqnxj3aadkml2jhqtt7xcxazf5t9el6a0ls04jgnq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5880,7 +5890,7 @@
     }
   },
   {
-    "address": "erd1u8s563uazhp3c8rsqyyc4engffnm5h7k87tl03sd59tkn4xsc67sch432x",
+    "address": "erd14q4e87rwznz3dqdd9uc5ml2tqggj866c2yvdcatp3nt6vxp5lwgq0vcg65",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5890,7 +5900,7 @@
     }
   },
   {
-    "address": "erd1lz5yve5yryz7pzzx3nspyns5lp74t4r47ngzk8f88mefgl34t3pq3ncv0h",
+    "address": "erd1a9wjtrpayrh5jzpq4w60av5hnesxn5gg8u34x5m9dqljmk7d2z2qdq2zug",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5900,7 +5910,7 @@
     }
   },
   {
-    "address": "erd128xss70pr4lk92mgtsaejghfecc373kexxl8zx5ezegqflcluzms0f5uxl",
+    "address": "erd1jhgdmw6qyu3nlmmxlhpefyyk6hkkc5jx7lxzfds4q389dz35zwjsq0tfzp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5910,7 +5920,7 @@
     }
   },
   {
-    "address": "erd1qnxzcxckdn4h5ha2p2c8rzwms4plxxgdrxegafucea9w4ff8jz7sljysx6",
+    "address": "erd1qfxuttkye92cjn0jnma2e44s92555n9haafkckpsvmrprje9wwgsx8kjd8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5920,7 +5930,7 @@
     }
   },
   {
-    "address": "erd1lvvs7pehgg458eegnu7vx4fhjhlv9recf2ek3sg232l22fr6gj0sz3wds0",
+    "address": "erd1uydlrhg82yrfeaz4mvygyy4yqr074fz6u4g7dyutzyjq6pc7hlnq3m6384",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5930,7 +5940,7 @@
     }
   },
   {
-    "address": "erd1ausgu4fstq03ratwdvx84w99ged0y0yr37wpfp7f65us9ewzmkhst730jt",
+    "address": "erd1uu8kfhg8vhuwu4yty47mhyjj09pcc5mt7wgzsly04kkjlreaf89qmfvfa7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5940,7 +5950,7 @@
     }
   },
   {
-    "address": "erd1gq7mtn2lvq5r6xpxqcdgvsaeuc9kf9wknrurjkd9fqa4mtaql0ss8jv2rq",
+    "address": "erd1vgvtzdn3rpvk07fppn7h03cnk0c72kslfmzvmu2nufufd4k332gsy7upc4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5950,7 +5960,7 @@
     }
   },
   {
-    "address": "erd1qrl8as9xru0mcz9xv2v6j63z5yd0q9mxjdnfj0dj7jkat6vhcxtqckdqvn",
+    "address": "erd196haqw00pdjadarql6cqhtf9z02vuuqpygs8k7t5ccz9qa6t6rgsrpx25v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5960,7 +5970,7 @@
     }
   },
   {
-    "address": "erd1znj59jfjf2lwn99q9a94vc0vfvw5jezqkmyv27cqp6zgfkfwleesj37u7j",
+    "address": "erd1qva78gjdcjxm5864dpxcwyuzp4c3zcdqtq5dx6fgpj7hghrm5klqyknlyl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5970,7 +5980,7 @@
     }
   },
   {
-    "address": "erd1xdnk5nhlc0wn5nzg00lfycnp07ncvzh5qeq57szt9nrcdgaea0cq8npzyl",
+    "address": "erd1dwxgkk24xvrqy2kesusedxxpvzecz5slkpded4ha4gw5qpmpghlqh7qedm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5980,7 +5990,7 @@
     }
   },
   {
-    "address": "erd1mmq52k2al7pellankcdv5dhcn8a6wgf8xxhppefdc4pek0pn0yjq7e9fun",
+    "address": "erd1ffws9zjycjfexwv0d4ugnplvmn6jr5clf0yha765av3wwlw8uhysp0xxhc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -5990,7 +6000,7 @@
     }
   },
   {
-    "address": "erd1andge2lncu97k9p7j5ny66xhskd2czzvyvzvufwtvpmmzwtsq4nqpty0nf",
+    "address": "erd1zg4ran2xlrq8l6ms4y4se9annrw2v4evsefxq2ucm24g8n099zfs085fj0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6000,7 +6010,7 @@
     }
   },
   {
-    "address": "erd1cyhk6x6teeaya2ue6j8junej8fw3ygu0xc8eyfqnz4x4gvyexxpsenxl26",
+    "address": "erd1xafx59fglgc0zf32z9jj5e3rkdrve0pwpqcnhr6y72rclw5hshzqgkg5yz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6010,7 +6020,7 @@
     }
   },
   {
-    "address": "erd1qlw3lft240ajg559w49a7l4c5xvf3wl05w85640c2vhu2jrw0zvsw7x92d",
+    "address": "erd1t0qatarqv0jp3jfp294a094kgn489jkq2kmg8ec68tsleqtpayfswfw8nv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6020,7 +6030,7 @@
     }
   },
   {
-    "address": "erd1mhvxs2zml2m8tsxl2cxmgvrq4j3kw4el5yap4quzc8k72895uxpqwwduyr",
+    "address": "erd1zny5jnjv9dsyferaypfzegssu3ez3752c227pd759g93wpmn3pjsqgwc22",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6030,7 +6040,7 @@
     }
   },
   {
-    "address": "erd19wnmlp8fs7ap6z0jdx3tk5366kjqz2ezqlmh4mlsxjj0a7ymdf9qrw2jza",
+    "address": "erd19uhnll552gqlsljj52yhxuegzwn48yahc9nhvz64zz944emezaas66vqpr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6040,7 +6050,7 @@
     }
   },
   {
-    "address": "erd1pknzw4rz5vagmu6hs2kf3yptmyeh5pkhrghgyrcuajk9j9te4s6qnne9pt",
+    "address": "erd1aykapxz6g7mql9ulu7nwm7gl0t89altfa38nr5drxq2x8wcg39sspkxlyz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6050,7 +6060,7 @@
     }
   },
   {
-    "address": "erd1hxrx67hegh83s6czv8a0av40qppnp5mry4pjtz36qh6x5g6emrnqk6e80k",
+    "address": "erd1skmwttzssr8yz8p805n5fwj4dg8kyuyhw778hrzeu0zhx4vydahqu3tgte",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6060,7 +6070,7 @@
     }
   },
   {
-    "address": "erd12nrtg06k9hpxryrhv0sycf8ek6t9ytfan8pnvanpu5gn6vzta89qn2eect",
+    "address": "erd1clcv7dem8szh9hkp4fp4jl8gnclwpzc7mpzmeyms6u6ef83jweesrvru2s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6070,7 +6080,7 @@
     }
   },
   {
-    "address": "erd15w2x5lgeeg23sp77wvmru9avz9jxksrk5vqzp6jp4a2etgqd2t0sr57w87",
+    "address": "erd1prqdcvz3e2smx9a5yk0hka8xcrx598cr9veu5m0mls6vc84zq96szqezxm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6080,7 +6090,7 @@
     }
   },
   {
-    "address": "erd1qyk3zj3wvzxj7at7tmz2c5vnypknp5y3f4rf9gs6xa6gagwkzhssr408vw",
+    "address": "erd1x3xknp4gzz05gc9xg9va6fgkjf282ev8n0epla09r5k8wk9xnzzsz8xvuq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6090,7 +6100,7 @@
     }
   },
   {
-    "address": "erd1s2kwznwxvqjwmjdtjjstxzvl25c3qxfrqu4julhd3ww7gu6tqnuszzmajr",
+    "address": "erd1v48r07eg0j00pxsyl0z8kr3skmpkcrryuf5r96xhdydhny3cqhas9uq4ea",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6100,7 +6110,7 @@
     }
   },
   {
-    "address": "erd1azd8ked6ypk028v6jgd9ca5sxy8umg9d5vpqsk7gvnvsf7y4dyts2c5gx2",
+    "address": "erd1gqf4vdxq0d3dv28z7xmqql9t2zttx88t8z48wry7l88ergpqtplqukhgke",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6110,7 +6120,7 @@
     }
   },
   {
-    "address": "erd1h574nj0n06httewsttkpqfh03ayejkgpa2fn3r29x0zf33fp9p3qhh0gwp",
+    "address": "erd1x4uh8dspdznvqa5jchwlm0te9k08kwxzfquu5qme95z4kd86r0tslhywe2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6120,7 +6130,7 @@
     }
   },
   {
-    "address": "erd16xk4qmp93swjzwejfea8gkl2ntz3a337gnecaf38tdawlgk6fd3swhcwu4",
+    "address": "erd1zrdmzffxsq8slnupdv74lnxx4rz96g305z6flgapmzyg7dvg368qlw96ga",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6130,7 +6140,7 @@
     }
   },
   {
-    "address": "erd17v0xg0ng78dhr0afdrd982q2rvh0krznr0rjw7kay9xdcpahfg2sg7qy6m",
+    "address": "erd1p3xnysewmwc3zs40zcz2ynhqg20c0l0p0cax7v0kg6xduxpt7xzswx4fkw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6140,7 +6150,7 @@
     }
   },
   {
-    "address": "erd18grq0h0ptuu28g4jsmlkxjfvx92x3ae5u3szls9s7vysfksa4jlqkckqge",
+    "address": "erd1dureferxrgsytklplalla9grql7vk6awurjhcp2zvrnfdr6py5fsvutfqg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6150,7 +6160,7 @@
     }
   },
   {
-    "address": "erd18u2uvtf8s2lc7hf9yy2tu5e8jnu4hv7rdwuqlaqddl5zcvhkuefsgk04xw",
+    "address": "erd1kt7j9smnvp3ce0ptcl0a7tplsfnqhtjxpdck4axa2pupeukxjwmqg5x00a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6160,7 +6170,7 @@
     }
   },
   {
-    "address": "erd1g5jjwfuqgwcuqhs0559fp78lcqucjjs9eqarn6xnwcn7ragy4ygs368c0r",
+    "address": "erd14jjqkkr0cj0jrvgexu4elu9h8jlmshcnlcgnt6t0xkafp2t8t4pqf65hyz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6170,7 +6180,7 @@
     }
   },
   {
-    "address": "erd1xtlt7myd98ruw8tj8d7smrnatkg28jp3ctje5pmxpzzftms5my5qu6pskn",
+    "address": "erd1gfrjk7f85fk63suc4ss2kang7ctgtzwqvd5mp7cgz600ngp08qkskdnaev",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6180,7 +6190,7 @@
     }
   },
   {
-    "address": "erd1y0vxzjnysw3wp62s9rvn64cu7k88z4205206t7gtyh6wwg2af3sqpccevd",
+    "address": "erd1pus4r40x36ze3p3rxrdzjv64uahj5s0vs6yqn3jwfvdkutglp5xswavrfa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6190,7 +6200,7 @@
     }
   },
   {
-    "address": "erd1ztm82rdm03x9cvzxvnvy5rz77nl49dn8c8yle7z2qdyhzaaxaulshcj49e",
+    "address": "erd14ungk735py6z68r3x98u8e8y2cp6qcfwknngqtu0gr2q8nk5l6eq3zx6xe",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6200,7 +6210,7 @@
     }
   },
   {
-    "address": "erd1phpcj2tx7rqqncdsynwj74gh5ndfdv32gx62rq5zn7q63z2fwz3qp4jn6e",
+    "address": "erd13w8qarz5v8s345t9u2gkh0w3nckqgg7rl60yufan5qjn90wy5jtsxxczuf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6210,7 +6220,7 @@
     }
   },
   {
-    "address": "erd1cj8uvmv02mnkh0k767z2mcz6qlux9s9hnp9mx3hfst47726qp0gs0y9fwy",
+    "address": "erd14wwcyydcprhtnlqlh2eycd0u7mtswfxvzndsj2jc8lpgn0x88aesqjx734",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6220,7 +6230,7 @@
     }
   },
   {
-    "address": "erd1fdhm4q6mg8cvdqe6atgw9dhf6am66nejd8mlntusxtrmma4us2js8vf62n",
+    "address": "erd19wwzpfu0r99afdjwty0svf57gka0snv2wzsdhf5ul4ejnslp2hps0kc8mc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6230,7 +6240,7 @@
     }
   },
   {
-    "address": "erd132vhkyfjpc3lcdlunzxqqc5amxdh936tdzmsu6xg3598flsrtw8quesgtz",
+    "address": "erd1ut922898z5sf5ztdgzcu2gprtjuywrwn3xm9qynq25xt84vun9qsw5ujtg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6240,7 +6250,7 @@
     }
   },
   {
-    "address": "erd13nxlhwpc2sjynls2ylp9sc3mf5yv8w8h3xcze4ux6dlt855450asp5p8xw",
+    "address": "erd1nhdkykwufsey6at5f4wtuftgxegnp9ucreq2lugayde9rmjh27aq8e7k0s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6250,7 +6260,7 @@
     }
   },
   {
-    "address": "erd1scg93jezrm8ts5k686eaq5am5h06258jh0j3laeqn6f2qkjlkz9sklaqa5",
+    "address": "erd13gmgcd78ukpgdmhmqsl8xlnhwp75p42tm5t46n7tmuwd5zt7gu5qjyy5cp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6260,7 +6270,7 @@
     }
   },
   {
-    "address": "erd195yqa6l3q8ypsrrcuxevsj8x477caszm3ugvar0tzqymkm8qzydql3su3y",
+    "address": "erd1vad3up7jdx75040w0tyluwxl4uhjaycvwt9azeefr7s2ufa4r6msw2l3pm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6270,7 +6280,7 @@
     }
   },
   {
-    "address": "erd1wy2danv3hxxc2yemsq2kndrdmj5s750jaa2y3t470ygdjkqcackqc53gfg",
+    "address": "erd1aa890wk472hf40xjla0ls2esn5ne6jy64ytvuw56t2dlkxkyv4fsjul54f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6280,7 +6290,7 @@
     }
   },
   {
-    "address": "erd1weqvdeysstkxlk7yxurm500kc2pdwjc7ezwda8stsktflk04dt0q9kr5r8",
+    "address": "erd15dtcynu8dcnt0ftr5nwnumr9t5mzrrasaa92e30qpagljftrlrdq5krt9e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6290,7 +6300,7 @@
     }
   },
   {
-    "address": "erd1zs2km3g5hkmpge3qfy3jmgql8zlhw6zfpgqy4jus2y5fw449mruq8ah9dj",
+    "address": "erd1lmz7cgyfkc8sca853epzfhwddwexxtyppncv94nsdmgche4vgxzs6jvvk9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6300,7 +6310,7 @@
     }
   },
   {
-    "address": "erd1ef34yqfh3q3c82drsrccu0npqqredh33pz8wfm20wutt04rjak6qqnxn9y",
+    "address": "erd1cw78c2s2spjx3vfr3a5re4kkvu2zy0dm7gp05ewtgmxeaamwm0ss77uylp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6310,7 +6320,7 @@
     }
   },
   {
-    "address": "erd1zm0y8gq39aahq4mzjf4nd0d5pm0prh0a55lac77uzt2lrweg72ksmzm4rd",
+    "address": "erd18397mj0x9xrrdzrsymp3g49ngjddr0enw42hfjw50pka63kuta3s656n5a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6320,7 +6330,7 @@
     }
   },
   {
-    "address": "erd1h7zhjdt4hwr5al7cq2eehcuzf3hmtns052wj074tfrvr3dgvfzrsggwvvp",
+    "address": "erd1j50glklw75ff2l0x72t53hq28qeyxaqp0glgc2xx60f7vvujcf3qwupseg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6330,7 +6340,7 @@
     }
   },
   {
-    "address": "erd145fvxw8a5cwakf2rn0rns340j0s7vl2vpn0laq3qercnasp5lqlscn779f",
+    "address": "erd1g3hvfz2gt7a7s6graf9g3xw8jjpxj3pd9r6jv9nnl927kn2ef5ys4cs9xz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6340,7 +6350,7 @@
     }
   },
   {
-    "address": "erd1y4qsrhs987ru058eq9xvm8xlu07nmn8sdach2klf5sk8psye3d7sr57r7k",
+    "address": "erd18j9tn3kqkud4l6hj6a4p3kpme2r6nngal7lkrtqzfwnsm26qdfhqh6za6c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6350,7 +6360,7 @@
     }
   },
   {
-    "address": "erd1g32eml82wkn9vhwacrl0m2423hjkaezllmkz9r945p7txqdu599sfzlrg9",
+    "address": "erd1wuw7pqakxuxwsmjdx8g93pz4aafjlge9h6qr3g0l4wzwu6vurv6sf23tt8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6360,7 +6370,7 @@
     }
   },
   {
-    "address": "erd19v6qzf7spc5s2nxxpe63wwzad2qqxfvy5qz4z0w6daudqahmhawsvmymu4",
+    "address": "erd1knqkajmpgt4sphgnnwc3h4qslmq4gqdqf07q6ax0jzdcwvag4wgqu8vxxn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6370,7 +6380,7 @@
     }
   },
   {
-    "address": "erd182w0xx4tczvzp3xh6jltpne0arnds46sdvrc022uag4ex0r6af2speg36m",
+    "address": "erd1ld6ekgrvz57qa9ljdpwx7x4m6g4wx9kfa40cn7r2wc7zrpf868rquhrqhp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6380,7 +6390,7 @@
     }
   },
   {
-    "address": "erd100r9w5kkwsesy8l8xmuaf70c83ymdaqkkd8sypcfup5aznytnu0szy3rq3",
+    "address": "erd13nfsujcdy5aj34y9gqr0m65ww2as2vvv4anzz5a0urrc0whxfwnqgjq5ld",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6390,7 +6400,7 @@
     }
   },
   {
-    "address": "erd1mm0jcz35sar4xlc65vp0al7d70uzhnmn0r5vhqsr0rjy9069fxzslsr3fy",
+    "address": "erd18vnjemf82uvhmtl7ya06enpzyk8pczct7n3llwjf4y09z3jl3dmseq4y0d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6400,7 +6410,7 @@
     }
   },
   {
-    "address": "erd19grqp9z569kyk3j8ke3nv9gwdta8kxq3d6wygg0gwk7nqt3rttpswutne7",
+    "address": "erd1lt3vt48jpfxjy9hwewn995v37kq7wf23l8axk9fax7qzrhfcuras8566px",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6410,7 +6420,7 @@
     }
   },
   {
-    "address": "erd1uraa3cp46avac8n3nygedqxadn5f9sjvx373hdktrjmcmwp2hayqnmphcr",
+    "address": "erd1zfhcwr2sje74yglzca6vzf34qt65pkz2lyn644qmvu0jypf7amls6w92ne",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6420,7 +6430,7 @@
     }
   },
   {
-    "address": "erd1denctglq0rxnzeew3r8z36juhtmrwy4wqrl0hc4qgkz5mgaregusk72vwx",
+    "address": "erd19tw6euzd6mk39mhtl069aygzu242nv2633aafal90s6fy4gqlgas9wrwe7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6430,7 +6440,7 @@
     }
   },
   {
-    "address": "erd1rwvsj38yskstvzn4njws909m7rk8enw3kvr56x9pwu8rq9p4aw9qua5xwa",
+    "address": "erd1hfentja6m0avew7lkf3xvmxmwq34dhxepuvksf3jxsldhjwpf9gs0jc2s8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6440,7 +6450,7 @@
     }
   },
   {
-    "address": "erd149nfccxesheke9c2jnd8aqa3z8ssvz65u9hmrmnn4jaaet0qth7qdskmku",
+    "address": "erd1lhnycfq5uep76ssuzckzr2zuap4twd784crjlejee05zqesgzjuqaz2rfs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6450,7 +6460,7 @@
     }
   },
   {
-    "address": "erd1gm6sq6923c3l9dsd2stlrdpeewfvpdhjv9pm4u4pf4w30fgm29ssdpr8me",
+    "address": "erd1ke25zsuumeq4scsn5q0dgkw7yaqsr7uw04emr3qd0a268q3dv28sr4u0cv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6460,7 +6470,7 @@
     }
   },
   {
-    "address": "erd1dysdt2e5n3tg3563tnqkkllrutv60hpcsg9l7pe8fv7en7zy3hdqyllc4n",
+    "address": "erd14k5npnxdu74enkzqpdm5pjkhl8xh5llr3grefddxf49fad9xdezs5ahvn7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6470,7 +6480,7 @@
     }
   },
   {
-    "address": "erd1t2xp69rx5pnpnrt4vcvmlwl22s94lf2wvg2amz4yu64a9qrdfyyscfa2s8",
+    "address": "erd16rnzwh0uh3lhn3j3png3yjthlujjm87v7vylmpm8j573kpy5kd5sg95kkt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6480,7 +6490,7 @@
     }
   },
   {
-    "address": "erd1psfr0qzst39flnqch4elxp09vr7etqp800rrg8d6f597g2ffhnlqwtamv3",
+    "address": "erd19twag4a66rlujnv4p9pmgpf8xfqgzu8zexmpjh2yk2gvt99xzvnsfm20ka",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6490,7 +6500,7 @@
     }
   },
   {
-    "address": "erd1g373vyt4nnj3y68pzd6wlezr8h0yzf954e6caajxd86sycuhwthqxd8s3g",
+    "address": "erd1xgxydlxm0x43fm7h08fpygshdt3yyewhdlwjplq4jfax0gsh5xjq4muexn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6500,7 +6510,7 @@
     }
   },
   {
-    "address": "erd1apvh8q9xt4h6m3q3kgct3rfxphywyn59aneffl08gch0ypzf3q2sqyavv4",
+    "address": "erd1qfkrvsn28hfy88ryrv8kn89mkn2kppd4a3gwelnwr5r6twueljqsgudue6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6510,7 +6520,7 @@
     }
   },
   {
-    "address": "erd1qmxls67m0z3acuj7ys9c32x725u2muafqre50y4gmhtf8lhvtqas3cpd8s",
+    "address": "erd1d0crjw2ch8jtpqf6s24f7vh7qr879wlfr7w5eygz4xmswjk4r0tsg0sqqj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6520,7 +6530,7 @@
     }
   },
   {
-    "address": "erd1ajt9al60g5en0dauvz208rq3f8jmfcgrjz9my94qvq6rhpt345hq3ylwee",
+    "address": "erd1kvv4uq2962yztdu9rgrssh63l59kpmrp8kktkcm57ksd3elpfunqx3ksl8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6530,7 +6540,7 @@
     }
   },
   {
-    "address": "erd1hkxrc038rqv2uacd3e45k6jsrhs5l8vy9c69ln22kvtv7gct7h8sr80s97",
+    "address": "erd126zyaggtz2x2e828gckvc9fd3gem9dufpuj0ejdlgqz0rkefvr5s5a3u7e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6540,7 +6550,7 @@
     }
   },
   {
-    "address": "erd1j0w5fxzg8jmkyllv4dp39dzutrfut6dqhutcvv5d9paemx3tm0vqvfg495",
+    "address": "erd1ytz76pjajpajg0epurxnknecuj83nznfwxqrpd6uderf9rf820qq6udjrw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6550,7 +6560,7 @@
     }
   },
   {
-    "address": "erd1qlmme24v9d7es3yf9psmu36tqmylmuz3mwm2wmf82zkkuas7hmwsayz74v",
+    "address": "erd1jzrfdn8uwgxsztrzsslasnjja45l2m2s4d7ljzfgl72s6j07gf4qytkhcm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6560,7 +6570,7 @@
     }
   },
   {
-    "address": "erd1eypau299zdmj8cwu6f7eur0724st5xxy23g7wnf8axnfjyn8xc5s4xdq3l",
+    "address": "erd1ezp3xkquedgqw5f4gagp3d3ccyfw2x05fy8ckgcfw77fysmdw4tqnzfwjl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6570,7 +6580,7 @@
     }
   },
   {
-    "address": "erd19zmqclfe35dwj3ceu37f3uulexkkl9jsny9k4yuv6uvhnmdz60sqzxfdwj",
+    "address": "erd1ukq476f85dlaw6td3q87ufhcyrp4x0hsgutrzh6yj6r8djquw0rscwwt7s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6580,7 +6590,7 @@
     }
   },
   {
-    "address": "erd1r9sksfaex68zw6348sa9z4xp0cyysc8xzdc09dm7zp2ej6lfzmaqnklvre",
+    "address": "erd1r4wgsmfzkwr0djncuq49ndjsmkr4ycz5vj0zgmhuyxg6tnpm74qqdekj6w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6590,7 +6600,7 @@
     }
   },
   {
-    "address": "erd1lknr0cu58cw7l2p4sy4ky0hjsg4mfc05mut63y0tv7jdn9k6x6cshsz83f",
+    "address": "erd14yw6hdd93jxj8kzp0t3sd60m7jyv2e7rk2c3xhd6h57rpsrfd5esv4c3yl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6600,7 +6610,7 @@
     }
   },
   {
-    "address": "erd1wu0ynjq0d9a9j6wknlngffnnqucpznhekhtk4w7pslmn5rlnjr7q8qjaq0",
+    "address": "erd1u5qhl3vh6exvfuxsshq7e5jq9l3a0hc7cw5lw3v0sctgqmfvjy9qqj5qv9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6610,7 +6620,7 @@
     }
   },
   {
-    "address": "erd18mmur0ad2svsf364a0du7jyaxqtcashcvkqy0yav2tkexxruhljshnql4m",
+    "address": "erd15em44kmj7t6n8dwa478r6q8nsfvmc3z68ax7x2j50ygrsfv5zums2r7uyh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6620,7 +6630,7 @@
     }
   },
   {
-    "address": "erd16myt63cw4w6jnpnpyrppy3upnvv6fd89mglzpkds0pndqxnuhpnq3dxu9q",
+    "address": "erd1ed9jlldw3ng5zn52hfg9fe3fn4fx2nt8p777nd7wjkhee7vkf77qepcwu0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6630,7 +6640,7 @@
     }
   },
   {
-    "address": "erd13kquwmlcs5tc8enudrpnn2h00w2nk7nyfxrkkv3ra0smt6u0scrqsfnfvv",
+    "address": "erd12lu87vf45ja8gf4qmkjedchglr5vue6drljpsnj6v2d9r23rp3gs7fudhl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6640,7 +6650,7 @@
     }
   },
   {
-    "address": "erd1vs2tpjsnqt9dk66cx9g98z5878nnemmluz4trt55zcwc66cdcz3s7wt3r7",
+    "address": "erd1mkg2hdgjlthxh5sh8zsxys74hqadjn2lkryruu6dm9025ym0v3qq482lz2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6650,7 +6660,7 @@
     }
   },
   {
-    "address": "erd15mxxyund4g9mcljf0y3w4y90padger9555zqwlgzj8uy8tk74auqw4ycds",
+    "address": "erd1zysn5wkntlgnqmss7gagk4r9txqk76qqwqd0nmn5ya7atee48essqmaush",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6660,7 +6670,7 @@
     }
   },
   {
-    "address": "erd1ganr5kdut598r03xwf97hm2tlvsrw23y57hshg5aykdx5y7hdgzsrv9p3g",
+    "address": "erd1c2ulkjmysv79yp90k5n934t59cz74u0uv54g4j6z8hwph9xsvvcs7m9vlf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6670,7 +6680,7 @@
     }
   },
   {
-    "address": "erd1cqhjzn2cavw8pqvn2vnwjedr86r8n4w53cs0mrefg560u8zfzr0sazfa5h",
+    "address": "erd1430jla4c26p6phvxcc3en8ttzr5ejawzl4lwpen4zrgnvcyxr2aspvlsta",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6680,7 +6690,7 @@
     }
   },
   {
-    "address": "erd1yhuft0m57duc4n2gshuw2e2gunxcxq74vvg7m3l24fqxjr9av6zsh3vlzc",
+    "address": "erd1wkw6d5239aknju660nq5m6sdtdee3cc6uwskksyw54tn83lpku5q0uk9er",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6690,7 +6700,7 @@
     }
   },
   {
-    "address": "erd1c4q2h2nra0zxtsh3pn7hq98trtcv08ys99d0zsmpvyr5nt447qeqc8q0g0",
+    "address": "erd1x4p5gzh78362uzkxfmwr694v99dkxg846z8j0z6fhmsj9dhuwjdq70ze9q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6700,7 +6710,7 @@
     }
   },
   {
-    "address": "erd10cst2pwngd2458fpelv7ljmkkc6nl93zfcqfnacthglve47uxtvqu53fq4",
+    "address": "erd1hhenkplf7npa8mu9s30jeyse76982ug39nxw4yhn24e8wyfv0eaqnzpnmf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6710,7 +6720,7 @@
     }
   },
   {
-    "address": "erd19r23cqaj742vjr0yf7qxq00y74kxxeu2jvx6kj2j8ufp9lysev9shs95ep",
+    "address": "erd1s5429lgvns7wkfehh8cvh93r2kfhju0kunw6z0d9683am6d99r6smv535m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6720,7 +6730,7 @@
     }
   },
   {
-    "address": "erd17wc7snvhdxfrnms827e8qjf5ccz47k5vs9un20z2v4zyj4cudgzseft8qx",
+    "address": "erd1vpjt0nu3kvmeqghjs9ywzcgq6xhx7nngucqee6hm9e36rgue88qq00wlpw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6730,7 +6740,7 @@
     }
   },
   {
-    "address": "erd1ll0mqve0rty8u7cds6mvhac6t7qtst0dumkvsdg9pz9saemlf8nsu4j27u",
+    "address": "erd1xlrcecw0g8p2lq4teu9jxg5w6ahemnk7ye0wrlk6pf2y79rcq0mscy98z9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6740,7 +6750,7 @@
     }
   },
   {
-    "address": "erd1sda9xsjrs5c5gjlv8k4p3d9xupltru0ktwan7acw20c68789qs8sg835nx",
+    "address": "erd1kemkcv3qwngc4jucst2238nfmke348649l7hllu35lvvmg0vaklqvspmys",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6750,7 +6760,7 @@
     }
   },
   {
-    "address": "erd1n24rvspknekq6x2j6lvlqp3jhn7peslnmw2q2gc7jg33qre4gpws4385de",
+    "address": "erd1x0gg4rwm05j54czkedm9lj2r4lgup94r5xuse39lxt2q9lxnjzasw6xdl7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6760,7 +6770,7 @@
     }
   },
   {
-    "address": "erd1cwns5vrvl37mel04v52kg90kahg3rw32mz2fujrdmj9fdt2d287qqln9v6",
+    "address": "erd1uxeen7phu8lnhs7n6zxhethkmahtc5n54fv8xzkau8f9x5ujtd5slmzlaq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6770,7 +6780,7 @@
     }
   },
   {
-    "address": "erd1wwdgw5cghst8vxvt8gr9e2v8yf4asapny39sz6egmeq3kt39g0sscvq3tf",
+    "address": "erd1erxmppgrg9wsyaalqhzzy2w9f9zqvd3pgc44zt3mg60hrh9azsrqhqz50r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6780,7 +6790,7 @@
     }
   },
   {
-    "address": "erd1y696a55y839dgyy9nwjlglsmn056q585slaz6xu7zxhxnfnvlc2qjmff4e",
+    "address": "erd1yr55cz54ccjud9yrg8fk46quupshj5wny6k0vhc9g3vawvkdq6cqtnn77k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6790,7 +6800,7 @@
     }
   },
   {
-    "address": "erd1lcpxnjyqmzfw5t8n90ag6yrcwthrlgewta5vzru32dc0s6m6f7kq96dpxd",
+    "address": "erd1fhxt9ddzgcdck0gqkqwzkehf7285655wedyzgzlesnu9ywj8kuzqsqewk7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6800,7 +6810,7 @@
     }
   },
   {
-    "address": "erd1fvj3yh82pptu8z0n8xsjwka9sawyrtvkhp0qg8gr8cxygx6tqllstwslw7",
+    "address": "erd1g40sgvrrk75c5kelevepjf5usseyahfunw4fjhrgzxs3t7s42dsq0cm6k0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6810,7 +6820,7 @@
     }
   },
   {
-    "address": "erd1hz9gyn7n7zvnmqhwz4nr4alx025xt30w7ylmlsvxcrdc46jx0jqqqnxj98",
+    "address": "erd1hnyvz6pzz44v46d9z6ak557ne70nltc2v8a36hru9tzcu7tjv35ql7084u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6820,7 +6830,7 @@
     }
   },
   {
-    "address": "erd12x3vhmj5rzvpgpfnlj3yl0jg9dwr77n6q93ej94e6kzmpwwhmjcs54c7mj",
+    "address": "erd16dr0qlrkzf3d4vwmfwj5w2sz7zae8rmry9lhjqltpknzkazxjw4qqydaxx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6830,7 +6840,7 @@
     }
   },
   {
-    "address": "erd1dfudhevec3n76xk06t8da9cg4txza6qt7vd6et9n40lkjrz4x5rs9fj4kr",
+    "address": "erd1crukfe472w7z566rz8z878q3qpt30j0f7jen9ygxahc9ss4e2wxqjr2e2e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6840,7 +6850,7 @@
     }
   },
   {
-    "address": "erd1paqgp6vux2k2txtk5w92ldp7txavl5fpfg6cpe2srr30sdfx495suyvapx",
+    "address": "erd12jtmgtzwlfn43gw6q7d4l67qqx2esh9kdzhljhrtcu9nrrvle76sp5nxk2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6850,7 +6860,7 @@
     }
   },
   {
-    "address": "erd142jf6jcpsdr52gr9glcmltptq3p2kf2g6332h4mjfw828nvw3anqghxehv",
+    "address": "erd1vs8wja24hwzna2ue5hy0arxlwgqkdmexlkxegpvwe0syxj2dj9uqczxe5h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6860,7 +6870,7 @@
     }
   },
   {
-    "address": "erd1hacvlfentrmlm3wthzm9qz62k96rh9fr9yepts3ft5uq476k39ms6n27v7",
+    "address": "erd1478xekx9uvlc0s95z0lyp2pzd8cw0g9lcp0e5g7gv00t03tfyu0srnf0ux",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6870,7 +6880,7 @@
     }
   },
   {
-    "address": "erd14zhap87mr055xdens29c8e40wjqxyzjj5axm0jdjq6tz7tfsujtqu59re9",
+    "address": "erd1ksa5z8j3t9dksx2xqgffn8uhyrgf73m99f36almdvc58kx2gegnqz3ge5r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6880,7 +6890,7 @@
     }
   },
   {
-    "address": "erd1lxhawlp3hjky32sq4uvaxx2fhcw3cm7g6vn8lam3s5qgv9sk86fs6el8dh",
+    "address": "erd1suj9dnsh3egp45nu9knu554pt5h6sgksnr3r4nmjxl426kfnkljqh4dysw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6890,7 +6900,7 @@
     }
   },
   {
-    "address": "erd1wdszf4493wauq72txq6v4p8vncpy6y7gj4wg8x63l45qtr84ngjsztqavy",
+    "address": "erd14jpfpjs6p2e68f55lna7c5dw53kt9wrs0zscy8yst4qnl2p6e5dqdtmnrp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6900,7 +6910,7 @@
     }
   },
   {
-    "address": "erd1dxd9c7u90cjeqgvs8j8zh3z3chnpnh26amp330qkla4dazyn7m0s0kmdl6",
+    "address": "erd1r6cr7vx0hm7vxykjtvsnwd3ypsg5sntr69p5l4l7wpch2p0hn5cqkjm0ej",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6910,7 +6920,7 @@
     }
   },
   {
-    "address": "erd1cmtuhwqq5etj279893992yj8e2pkcd6uw6jlt9nfmet7q2cs4apqwekj5a",
+    "address": "erd189xue7nsleh2rkumf4xuujhtvaqle4mhf25zpxgg5gmv7cqmg2sst8chaz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6920,7 +6930,7 @@
     }
   },
   {
-    "address": "erd1uqm4z38ccheankngg2jv0xzxtgnmnnamyymsxv952tc7cuvsrrmsrfdtgl",
+    "address": "erd1uyx0lqrts5uuvsp4ytlmute3952alv0g6ll4ugpcuxwd6ucnzxssvjycuq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6930,7 +6940,7 @@
     }
   },
   {
-    "address": "erd1qh6g6ux46x6namv6lfglm4a9kh5qv7ug20wxqzgmma7sypxvmu8q2y30ky",
+    "address": "erd1qjztz3qxuzzkxx3tc26fsvj8kagnayvuh02yz6ta2qe9vdh3046qc04fw5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6940,7 +6950,7 @@
     }
   },
   {
-    "address": "erd1ktgvz7j6jt6v447vj84udnewyk3rrxlmy03x8dju8kpqjjched9qv6f9qg",
+    "address": "erd1m8akwzgem99j5ju8kp8xmt5n3vlpr0fga8ljfme5qllnkdc3285sh6j9g9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6950,7 +6960,7 @@
     }
   },
   {
-    "address": "erd1zma674dvs50sy76pkxz999cw7s7exl6xftktmts8fudzdg2y4tpq3ep2gf",
+    "address": "erd1elvkjvgzddcjmv0ank49p7920q5t52ea4qxd8arly9ynrsk94nzsyqwnqm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6960,7 +6970,7 @@
     }
   },
   {
-    "address": "erd174asnkcv5vvewnks0ymgg4ar4ecw6p6rxxy7mtpgv2s5d9sqr4rqa3hhgl",
+    "address": "erd14262pjf8sz5l739ud5hya6frpfswaftqawew5t644n8kangy5ncqzukcy2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6970,7 +6980,7 @@
     }
   },
   {
-    "address": "erd188q9dpqzln5yw6kgv6a95hy4efutjjlj2pg376tc9zn2zjky5a4qflzr4z",
+    "address": "erd1ks04cke2hzlzmwpc7cy875qhkxhmylqfvm8xng6lwu9rtex46zpqr0q0cf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6980,7 +6990,7 @@
     }
   },
   {
-    "address": "erd1qq3tsmprjxfjtm655vq2tf89hyjv2mvsltcssjf82639w2yglzgqnnpsle",
+    "address": "erd1nv40c8rxsw8a2x4n58d5l20f3pcmcq7ke5fruqeq8aak85sepvdqrt7nvv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -6990,7 +7000,7 @@
     }
   },
   {
-    "address": "erd1ez3hk2w5g39mqlgg7s8kvklkzp48j4sgx29607708x48csesdp4sft3tuk",
+    "address": "erd1ytsg69x260x5jfk5m40kszhcl7uhst3mkuakujy6wkackvkgl6zqgzlvgq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7000,7 +7010,7 @@
     }
   },
   {
-    "address": "erd1wjq6frulmtud2egqx4xd4ut2qayhlp2k6dzg2rn4ygkzd473zyds50vy9f",
+    "address": "erd1wm97c2gk2uhmkeu6es92vqy70ayy4vpnw62265yk9ge2ayungzesm4w32v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7010,7 +7020,7 @@
     }
   },
   {
-    "address": "erd1lawpsrj5hptmqd8tnjmlw5fy37qeqy77854le4rgx5u45u3yxadqca2fuk",
+    "address": "erd15ax0yh4ty62xjyeyxslm7hy0a8qlrp8sqpt7fspk6zfqq5jfgn4s3v5z28",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7020,7 +7030,7 @@
     }
   },
   {
-    "address": "erd1dlzvrf24kg34r8vgtzv00edz6xk33sg3ep7thcsq5z3lqpy9j0ksxdtgas",
+    "address": "erd19xvg9xn8kle69nhaq8z70u5yrkcd488euam66n7t9juj0fh96z8shhegn0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7030,7 +7040,7 @@
     }
   },
   {
-    "address": "erd1d93etf0vgaeuc2vxgfgcqe6dn2duzay5ka7pjdxkeaaptj7pm62s7tjw3d",
+    "address": "erd1nnvhd9epxtn4dh9tz8cpp23ghdj8ufhvg8qluqchcxsx4jcx5g5qkc8d06",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7040,7 +7050,7 @@
     }
   },
   {
-    "address": "erd1h2mft99c86jkv28yjqp4yj0u44ndclgw6gnd9p6atc7dzwr06ahq8rg066",
+    "address": "erd1hy6lm3d87yf0wx2y0y95kpex0zzrpafywqnfmjure8ek6amlst4qx3z72a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7050,7 +7060,7 @@
     }
   },
   {
-    "address": "erd19vc6julyhr4qk3dehlc2r7gndpx6gu8tgqgq8yluevjeve90vn5srlcdr0",
+    "address": "erd1l4kvpqa3azl37yruqpvaykvka9nlku25e0xhjpup6putcq6w8tfsns78sp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7060,7 +7070,7 @@
     }
   },
   {
-    "address": "erd12w9asfz6uw806hag88t906tm4pu59c798ddevywwmf9c9wzw8gzsu2vhaz",
+    "address": "erd1r7a47y6nfwsf7cqghsdu67frl2u8r82ylguhalwcalh40lvhfeas9z8a6n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7070,7 +7080,7 @@
     }
   },
   {
-    "address": "erd146wkn4gdx2zuzc9a5ej7kqdfucrdvdceus2044zsx5tdldqaz7kshfyjf4",
+    "address": "erd1fucfghr2l37mw43nw6udfyn3drpyqcm7cm24klrptgfwwx4mw5msa245xr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7080,7 +7090,7 @@
     }
   },
   {
-    "address": "erd13psqn0svy4ekf7lhat9rnsz8aad7r5ffjcjc94hthrwgjekt57qsw0r8jm",
+    "address": "erd1dth9308mw5x6xxa9v7kjxpdsnkf0jmtdt9k70dz2fcy9kmy7zqlsc8hhnm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7090,7 +7100,7 @@
     }
   },
   {
-    "address": "erd15peenkttj49c4ufmyps6h9dpk83dfh3etkhtsthfsgnj5d5gs6sscge4nu",
+    "address": "erd1rd7m73qejwg8pak3j339fz835ufz9gwx85wdqmws6x9dx2hmgnjq7ewyhl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7100,7 +7110,7 @@
     }
   },
   {
-    "address": "erd13n7mf55vwwdn5rf0nmxgvsx6xax84qcd05yr2xkdv09yn5ra3xts4s0464",
+    "address": "erd147d8xewzpduf7ggyd3cpc7n8jsy2e98vn75etkeku78zh2eua6pq5mnpll",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7110,7 +7120,7 @@
     }
   },
   {
-    "address": "erd1u3k42xmas55jva73vt29rsr8jd9zlejumvfz0aj6jf609302yjls6te6pg",
+    "address": "erd1r5j6p3y00s58s03fcmdz45xzmmstfawsgs72hm37arsmwte2sw0qawq8x6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7120,7 +7130,7 @@
     }
   },
   {
-    "address": "erd1cw5nyyzs4wugtrys8hxy5fxehntwuu007jqd4jd9wtv5nat5memqf50hwn",
+    "address": "erd1apcmuga3e39vfkdarzkfdd79clfunxzd3eqx04xjc2r4l0ceq97qqwtc55",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7130,7 +7140,7 @@
     }
   },
   {
-    "address": "erd1w7vyud9wjktemmd947kccqzt30kwkd3j726y2uu76u9cr6s5ka8qzu20ft",
+    "address": "erd1lu3fex8aqt3y6xvq6g7wf45yehm38hz9m2yht2uszsufh6usak8s3m2q4w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7140,7 +7150,7 @@
     }
   },
   {
-    "address": "erd1g5rrhk0k2aexmzyc7ecwjeenpeerut232dgy8kt0d0gl9v7el6psfeusuz",
+    "address": "erd18rclscrhaga0g3pdmm3tmv4j7q467e4sam6j4ex23hf5szfjmdzq6ajhds",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7150,7 +7160,7 @@
     }
   },
   {
-    "address": "erd15gcxedjjrhllzd0xrxp89e7paychwhtugp827lv37lyn8jcm559qxkc8lx",
+    "address": "erd1qml2vy8pkjhw3e9x4q8nqu6tcg0wsukwcqwsexwrrd0jdtljtsyqs7exm5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7160,7 +7170,7 @@
     }
   },
   {
-    "address": "erd1nud4sxrvyx94v9m3g9y0vjqdyfpq9n9c4y4uncfnmg68prmqmlaqsrze2f",
+    "address": "erd1uf756e4wysxdmf9dxxtkl3ytwgv66dpsmx9hh33u29hjxrcvs8esl8g7k7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7170,7 +7180,7 @@
     }
   },
   {
-    "address": "erd13d7wv94rjzqm4gnkdy0jph36692fe93lxk5rxkcg4hzuand84jss83dsqf",
+    "address": "erd1k7qznvmcd3gcyugmaw873frec63852es362gtx6vk3z6xapzt43sqt4mpu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7180,7 +7190,7 @@
     }
   },
   {
-    "address": "erd1e5u8gj57rxr3yacdq4k0p57427tznfa2xyzhszrkrer33vszrzusev0z80",
+    "address": "erd13l9yss2m48llz2xvljgw8qauk3t86svzdx295xne6ypst5epzmuq4eccwl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7190,7 +7200,7 @@
     }
   },
   {
-    "address": "erd102x9tt2ukuwk4w9axky0x2l08anu3ussg0dvv2tsg9ck739uyrwqq2sjrr",
+    "address": "erd1nekq79pf77p4y70q99wrleth8m4ed7hekrmzwcacjvg04lkhexwqrvu238",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7200,7 +7210,7 @@
     }
   },
   {
-    "address": "erd13fudrt0agyqhnw9m63cf60hnyes8yrr6uscysueqf28u88hysg3su07pwq",
+    "address": "erd1flfuthc6n74zaut62qkx5330ke6jw22l6tfdeyfw3tmgl3z5qmkq3xce0x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7210,7 +7220,7 @@
     }
   },
   {
-    "address": "erd1ew6hj34ewq4hr80hxpg7v5lld4y2d3tqyla4lx2kqwts4vk489uqquuxt4",
+    "address": "erd16lyyhsyrmehgewnxadyfn49rqn2z8tqmuj7dcvx70msgsfsmmg4s5dmql4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7220,7 +7230,7 @@
     }
   },
   {
-    "address": "erd12tt8vun5gqjqyeqv8t28xe0qrdj8w6638sz8vywsk2u3h7mrk35qt0vf63",
+    "address": "erd1ees3j0u22smjrkam9p7gzasyp7ew2llasgd5g049u964ywl8xeysxvu7lq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7230,7 +7240,7 @@
     }
   },
   {
-    "address": "erd16hcr3msaqy3x3c206n96npnfkdhldzrje2sexx606trjxp26zwjs6y8nrv",
+    "address": "erd1a5j8qrvqhw25rhfu74lwllum7kqx8jt9yjn4s24p6uqgfv0sfd6sdpcl6f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7240,7 +7250,7 @@
     }
   },
   {
-    "address": "erd18ycwqglmf4hak3mn2vfqj34vl8zjl7rr5867hcksrpg6q24p0r7s39pj5r",
+    "address": "erd17c9032qpx09prqgptzttylav6vt5acsl3h6ncrxqtajrj30kg8zqhl9vr4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7250,7 +7260,7 @@
     }
   },
   {
-    "address": "erd10cwusktr3fa77uea6kytqywq7d2lmtq52ut2dzq2n50n3pk4jxuskkrfp8",
+    "address": "erd143y0j87n9x23jces8tf08rn55q8myl2vsrga2rn0x9dkzgghmmwq8huuhu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7260,7 +7270,7 @@
     }
   },
   {
-    "address": "erd150qm5d405w69td7mw3zf255mzltpzlruky4laxkmhadktrjj9urswpsmx0",
+    "address": "erd12zv9yqfgdxf97ayxjemdru2dm2lpstasvlh37hnk0nlt3tcpaq0scla4fx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7270,7 +7280,7 @@
     }
   },
   {
-    "address": "erd17cna7wz3nsjvcm3xxc79jthpxxkzm4nvznr0n28xeexfvrsg9dhqefxa78",
+    "address": "erd1q7fk8kgxfdvnr4ymajevjmukgvfptysajf54d4rs6lv73fsdvtrqy3reng",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7280,7 +7290,7 @@
     }
   },
   {
-    "address": "erd188kl2uydu9l5pa2e9fvk89k0gcxxczm4ajzqwfgc0208geuswmksvzuaxv",
+    "address": "erd12lxm7ct76m6kztaw575vz8x70sxut78csm5k75q59r2cku4pjrxq3helkd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7290,7 +7300,7 @@
     }
   },
   {
-    "address": "erd15t09umkhg9c25z5qmsa97qww5csyde3ta3detnx794rst5rn05aq7qlqam",
+    "address": "erd1f8r65fs2nzpf3ng4jmxr69und5vlk46nmvf8egnqr2mmjzkvr49st4gtpx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7300,7 +7310,7 @@
     }
   },
   {
-    "address": "erd17lxfh4nhfsd0dj64trewq5l2nk33lvusht7ze2fw9lku5kxf0tqqvn7dd5",
+    "address": "erd1h89p3ssgkx9f2txsz44mmz5tgy7kx3z3qt8sqtm22nvln3skdeuqkefh9f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7310,7 +7320,7 @@
     }
   },
   {
-    "address": "erd1q8kfpeyn6y67a7xjgcd2qeull9j50fxdqtwu677fhm0303fgmqaswp552a",
+    "address": "erd1flrrtqp3ufq3kmrpy3dhyflc5kqef92cf74tteuswqa8u56ys7ssgqtk79",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7320,7 +7330,7 @@
     }
   },
   {
-    "address": "erd13ddu58e7tkmm6glt0vad2vckddzl8ds2m9kw6mfdrltq5xev022q09yks3",
+    "address": "erd10pvgp2vg3p52gy6u9pcxcpfn8f5gzs2nn0a7q82pq0ust23kg7kqr382l7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7330,7 +7340,7 @@
     }
   },
   {
-    "address": "erd1lamjn2m725tklqe459j5tmw63myselpmw2wkk67nfy0hsyrn332qg9e6vl",
+    "address": "erd1yw4k7s3tlusjaq9tkste3lkr2wdwq3ydm87ulyck93a3w0n2kp3q2mdh8n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7340,7 +7350,7 @@
     }
   },
   {
-    "address": "erd1pwsetqx6zwdal8gh538e8n3e6my6gh2y73y3wmkcz22naz5lp7zsnjw43p",
+    "address": "erd1yr8mfguxarfrtqfr7d4qywt4fgtkc6qx5jn3nfelzpk9g0lwns8skky98q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7350,7 +7360,7 @@
     }
   },
   {
-    "address": "erd1qldl5ud2zhjfazsy23ezp5sfhw9yta84a3xwk9vfttzhxwzz6fjqegj072",
+    "address": "erd1x8rwtfdm77kxwmfnz2aet20kyj67s7f67rnx89wv6rzjahy4m4zsla9yks",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7360,7 +7370,7 @@
     }
   },
   {
-    "address": "erd1epuukpymzc5l099ltf6zs88l74c6clf927c4ecjnf2hfqjns5teqtjhkpp",
+    "address": "erd1gpcx0nz2v2p8p2azfvstxxqeafglclusckyz604x3l8e3n2tf84quvep8p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7370,7 +7380,7 @@
     }
   },
   {
-    "address": "erd1w5tm20vm5g8am7cesc7cprscgqxp0ay5g2yzpvskldxg6y9yr3vqu52nm0",
+    "address": "erd1lsws8kkvmz5jajcn4xnuddwfl74fuvfdzeh5tsc7547763awl8hq7xlkp6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7380,7 +7390,7 @@
     }
   },
   {
-    "address": "erd1ftj7rard8accna550evmtjghzntvzhn6uc92qhjux8s7rvrrazsqq0mn0e",
+    "address": "erd1j00wmc3dtla632prrf83ssspq876w9vlhw0u34yaa68tju24yw3svpxvvf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7390,7 +7400,7 @@
     }
   },
   {
-    "address": "erd10pm2n20gl8r0klzkpa65e2yap8glahhkaansyk8qtdk2qml6uhrqr0ehdt",
+    "address": "erd13h96ts04tmsly7q38kzvxtypq9hmupmx8zgvfaa2cpn3f4020f4qqq6g6u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7400,7 +7410,7 @@
     }
   },
   {
-    "address": "erd1hjz89dezulg9uejw96jdn3tyr23gprqutaavnqkvm7p2qt470zxsft2yn3",
+    "address": "erd1smeh4x65ht0wak4jc4uzwm4g97nxfflsh82k37pmjpvfxj4fdk3s3az9ne",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7410,7 +7420,7 @@
     }
   },
   {
-    "address": "erd14g2jdj9fdkuq3w4v8mezc6nt6jgf6p0t2xvrhd6jfxjs4580l3fsg8dk3v",
+    "address": "erd10uu3jm974n8fcdvvru8hvth86xe6ep93e6xsyalna3894s2dh76ss8a27t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7420,7 +7430,7 @@
     }
   },
   {
-    "address": "erd1k5cgfpludxycrty4hvkrfk0ljtqhcv6f6eeyf0etmeckgncmnx7svrwnca",
+    "address": "erd1e27r948tmes4xe6c7p0ypv5mf74unjj58egxpegae49xvjq3etrqhxe6us",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7430,7 +7440,7 @@
     }
   },
   {
-    "address": "erd122m6nl8nft5z3lv78w3a6aj207gvsxgetgy5z594yds8whh67r5qaq5955",
+    "address": "erd1yjct5ghf4ntfhwplt40n3gk64gtp5dnld93l24vhdkzxx0a5vlns2wy8nt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7440,7 +7450,7 @@
     }
   },
   {
-    "address": "erd1scwel4tray0zhptlxgdead3fwuzgjzdkktfmutn29whgv5gq4u9q0qjree",
+    "address": "erd1ekpggudla8v9yqfa0lmqf65d8mn97veye3zz23grq2j8fwsdl0qsrrvtvy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7450,7 +7460,7 @@
     }
   },
   {
-    "address": "erd1yyd3zyhx5fwn9j03xaa3qdhdg2sfjjc8gwz6uwlq9n7pmu47mslspjf35n",
+    "address": "erd1ne794mgjp9tde76wsxg6serzy2kypgamh5q8qq7vmm9lamd3pstswcc3ak",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7460,7 +7470,7 @@
     }
   },
   {
-    "address": "erd1ec027ujnp8677yluy8rquvtcj9x099zyfzfg88v26jc347u8ksxs3qkfu5",
+    "address": "erd1g8m4yj4e2qsu3klu8w4u0m062u9xkxpw4ve2urqesy5ym7320r6s7pq6e7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7470,7 +7480,7 @@
     }
   },
   {
-    "address": "erd1crqzwvfmqpclwgufl6tv209dd5yys29yvf06cvnvx9jzgr4wx8lq4887m3",
+    "address": "erd1h9vasjd2jllks9ejn3gep5hqznp7qkuh0g3n693afv7yyp45088sy08kgc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7480,7 +7490,7 @@
     }
   },
   {
-    "address": "erd1lezzn0yxhn6qztf2dy6arkms2xrk9kgty0s0xxq30t7ettuawaxqh7nxt8",
+    "address": "erd17zm3m60anh5cuhhfdrgg90gd7k8jet4f9zdz76j8htj84e598ras639grc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7490,7 +7500,7 @@
     }
   },
   {
-    "address": "erd1swcwvwj9fwv5tt3jkc3g0mz4j2hqx4k8zd956pkd9w09x8mry6jshlk0fy",
+    "address": "erd1jxx9a6md5ulhv0t6xkuppge0lvtw5gznlvat8052m6qhcp4knqkqz6u3wp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7500,7 +7510,7 @@
     }
   },
   {
-    "address": "erd1nh3s236s9rflkw9l2zyw7revtplzvlsjscm92h55qzat9vtdd8lqsxmknu",
+    "address": "erd1krhkmzcypupv4gz86dc0qs4gjtcrvnlcmrp2speq2k564ahsadps9grnyd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7510,7 +7520,7 @@
     }
   },
   {
-    "address": "erd19ksdd02h0q3s0gpxj7wgu7dl3s9t0dw8zdep2sdrx0s2erx7pprs8z26ev",
+    "address": "erd1v9ct8lz095atjga7zwgh6pm6w4h98m285w6nc8ttl3hg5suk0fasudnza9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7520,7 +7530,7 @@
     }
   },
   {
-    "address": "erd148nvcsyffgydwqt8ap3exz6latad3a7m03lkumu7kzssp8jp5gask37kx0",
+    "address": "erd1zejx09n3gelgm2utllmc9k4w3uf9yrnpwd77euf5rxagtypecq2sx6auuh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7530,7 +7540,7 @@
     }
   },
   {
-    "address": "erd1mc6w92jemtpw9s8v9l7e6ahrc0s2zkslyxv83x3nwmdh89uuwy9q92gf2l",
+    "address": "erd145rsyak2sm626jyf3dqgg34652uxgh3e9w3rkq720qz93vatljlqzqzf5r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7540,7 +7550,7 @@
     }
   },
   {
-    "address": "erd1fq0kc2dhsvm4cww4tjasq7hh5whncav8ky8hdmp90uxjcc8xe9ts2mmnu6",
+    "address": "erd12w94dthkpwajq5atuuwr4tq593fhsjwvy6e8u7fh6x4f78a0asvsyjnlvy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7550,7 +7560,7 @@
     }
   },
   {
-    "address": "erd1ku32v9kx8kexkcwhw52t3survekyl75va5875hdcnumr2rquj5zsszyahn",
+    "address": "erd1s80mthx4eh4v0yd47mmwnkfm3u754dgnvszeendqzwynq4j7en2qxgxpre",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7560,7 +7570,7 @@
     }
   },
   {
-    "address": "erd1svepjvdkmjdzdeyutnyurhz7raljmwe65xunepr20v05pw9kcslssgc3c2",
+    "address": "erd1nafxfglfauslqugglj7tlsxjf9lr7ffmjqmrtasv35avnv2ve4mqgx9ks3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7570,7 +7580,7 @@
     }
   },
   {
-    "address": "erd1n8nryy4gktypz9cdslzzyn7ju9p3ytnmzlwmdf5r59gr73qlspxqlmzt70",
+    "address": "erd1ukemmg8x32nhv54vs95784xzqtt4csuhc4t45x5f538479vft30qasnvvr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7580,7 +7590,7 @@
     }
   },
   {
-    "address": "erd13y7hnltph6tvxadkzduhrefkue9qslhv7zdv7cudagatsrhtcdcs69xrk9",
+    "address": "erd1e8y4szytamtt2asun9j8wpfnmarzvrvxme48y8d7w6rrr6vnrwjq5d3cje",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7590,7 +7600,7 @@
     }
   },
   {
-    "address": "erd12fme87qlskc44x53rxdd0al00ha0ufa763e4hxmqrfls7y4kk7tq9fz7sj",
+    "address": "erd1a73kynpk0p2ywer9kq8rn8f4t36wwg6gp6s5ynqffxw07a0tp6pqpw5g8w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7600,7 +7610,7 @@
     }
   },
   {
-    "address": "erd1qc7vh52mzg4f8zjm9wdsdua7jmk28kydz8q5xzv0k2cu7sxx23zsc3t5l2",
+    "address": "erd1rqhdhl7z780lfhuk4dmvxcvskrdyct3cn72jlh6th7eagp9erwnqdwryk8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7610,7 +7620,7 @@
     }
   },
   {
-    "address": "erd1vsrk79rq4325nftc7cpl70gych8tj52d56k40vy92g6nc3ppxdqqpmv7j2",
+    "address": "erd10x0n0jze73sufpc3ud3fnpgta999w8wdggnq355pc2fl89cvwxuqwm9dln",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7620,7 +7630,7 @@
     }
   },
   {
-    "address": "erd16fx3zd6zx97pr9hxrcar9zjzsjf3nd70nccc3gathpz5menyqvmsjdjfgt",
+    "address": "erd1eymgv6tx0wn8m7j06typdd7l840syl0q2m6jnlu6wpukdsrzj0mqdsu7rn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7630,7 +7640,7 @@
     }
   },
   {
-    "address": "erd1zh4aummwl8txdeeuywjn7rd24ghzdyad4vrwnm74vquy3jp367rs6j4drs",
+    "address": "erd17kum0gaqclke4w8mefkjmlq0fuaykc9d9xd2ns9phg7g4xwfunsq9eqhfh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7640,7 +7650,7 @@
     }
   },
   {
-    "address": "erd1pytxm5z5y5hvuzukg640mu36uuscedx3723sc3kgtvx82v5a2tdqnt5qdq",
+    "address": "erd1ygr53y3p5naxygrcf99zyhr5y9gpcle9yl854pme5vdje8sukzjqney2nx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7650,7 +7660,7 @@
     }
   },
   {
-    "address": "erd1z73p9fh89frsp5qqxh82z76nqu55c7hqnrcclpezepj3tpfz2csq7r0nlj",
+    "address": "erd1s9cgxdf9xyq7rp24x62k9cudqcpq290y4zfmjf6ze27df56znffqe53l4d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7660,7 +7670,7 @@
     }
   },
   {
-    "address": "erd1zs33kf6txptlx3kggrdumn2dmadf8w24zw5x7wa7etau6krw69rqlq4w4k",
+    "address": "erd1vp2lqggrsfz2a3ups4revace4gr8vs0cytgca4n7vs4suc07ja6qvmpr5l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7670,7 +7680,7 @@
     }
   },
   {
-    "address": "erd1uwl7p6mlnm8k565krpy3qc84apfpnpnydxu6le23g0ncfgv0x35qttpz4p",
+    "address": "erd13c2an8dxj67n37e7rx7xms94auw3f4pnr3xg8e3dvclg230xacwqrvdz0k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7680,7 +7690,7 @@
     }
   },
   {
-    "address": "erd1ard96ds63th8pqqhrk5dfudw2n8tau2hwdymyaj8j9mf80rfa9xq7svqnv",
+    "address": "erd1dp8a9j4y62fqsqwcrqv6z4gzv5el8znkgywew5fluncj6q0zk7esf429tw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7690,7 +7700,7 @@
     }
   },
   {
-    "address": "erd1tfkxtdnx69tt0mrjme3fsyu4vlyyzetayemtslyjjxeerms4t4jsczqx7t",
+    "address": "erd1kvftr7pcz6gu8ywxwk2qwddajxs8sdcwtmf0x09vtw620dgy97dsmgq00p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7700,7 +7710,7 @@
     }
   },
   {
-    "address": "erd1rpe3n8369q7mnp625wkn3y0elx4g57h6ja67n7xfyjq40qq9c35sxda64a",
+    "address": "erd16ndgsthwm0geknkxkh9l33v8u4altftcqgq0p2vday85yeh8sk8qac03l0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7710,7 +7720,7 @@
     }
   },
   {
-    "address": "erd1qr5s4j0qzvlm9wpv0fe57zf5fmfl3p79828539848qfrwrs6c3ksueg65j",
+    "address": "erd1z2q3d3lg4fqvvrgd8vhh0nz60p8ghh8cwz26yxtrff0fzjqawg2sjrxl2c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7720,7 +7730,7 @@
     }
   },
   {
-    "address": "erd1tnlmmr3y346mwjufmupnq6y0c8xtck9m6j2jcja42zclla93ud9qmg4csk",
+    "address": "erd12sy04492fhl6td0xmd0n3mhvjrfs7eyks35wze299ynufvq4e80qwnxrh7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7730,7 +7740,7 @@
     }
   },
   {
-    "address": "erd1nwhnkdgeg7qsaete8hsq3e2p6ytvrhyratjvh0rzl2g7vhx53q0q6rda25",
+    "address": "erd1f9kkczf6czahtg3nwqyh4j6mdtz0yar7hwx3dpr8wuupk78aujyq7e6qt7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7740,7 +7750,7 @@
     }
   },
   {
-    "address": "erd12jfkqlsx9ngle3g9drrhzjf6t0pa3nylsfnrr8wyh9uw4xwx8cxqtg5s35",
+    "address": "erd1w8vfgydt9y2h6aqfqh38aess4c03vrr3aqwtx3qj820vxehj5n9shv66cq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7750,7 +7760,7 @@
     }
   },
   {
-    "address": "erd18qlgh045hd3h69z0r4cszfvpxmtc8dl6t3p7hkcmjfx7m76cgtps63kum9",
+    "address": "erd1wzxnmas3ukwfhm7ngd7vyye46np5j846urx4yj2z0yt3wyw6ajfscl854d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7760,7 +7770,7 @@
     }
   },
   {
-    "address": "erd1hjmtnztft3jd8s672qshpg3z6kenfl5qew3vgcul0vd7mclj4gqscj6amw",
+    "address": "erd13fq94r4hfaqmxtuj2cx62m42807hekhcrz3rev2hfav5s09mq40s4l37ps",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7770,7 +7780,7 @@
     }
   },
   {
-    "address": "erd1gkavvg0sfxdk9h9mhpsjqgqyxcecnzhkk3hx2zl8gx8flw9xglssrdedha",
+    "address": "erd12nw4y8tv3nceh066ttt6xxkspu0s3qa8e0x2takgul77re2qdfvq5w3h78",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7780,7 +7790,7 @@
     }
   },
   {
-    "address": "erd1v4w6sg2m857s2nzrhqyszyx7trjm5eves2w7yfh6pqgpt7u43rps78cwq2",
+    "address": "erd1y7gqyf2xdjwyxjkmytp3ad3pgmaqmgjdkus27l0r7mkxnfqag2xqn3tmds",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7790,7 +7800,7 @@
     }
   },
   {
-    "address": "erd14ljczsfpchy7uz03ahl3uezaqaynsv5qksahvxc4rlf6xkpn53nsywq0dv",
+    "address": "erd1uenlhtf7r0vg5wcd63rcck4dtjyghkzl99v0ry2t6r47e3ukx9ps0va0ax",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7800,7 +7810,7 @@
     }
   },
   {
-    "address": "erd12lsmp2ae7r8dqds2xytykvnv2crsy3kjc0fujgtj3wxdlaxq4mhq93pxmk",
+    "address": "erd10r57r6cke34c9np0zfcnr3wepsphvuqgq8xrrs2ke4glc8lr29vqajxp0z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7810,7 +7820,7 @@
     }
   },
   {
-    "address": "erd1zvhwws7kvqg785k7c0a86cyzw2ptydc7dkjz9sffr7pcdrjtnfkqtekkaw",
+    "address": "erd1me7f30mn8d8mkjaucce06cr7gh854kwrk7uan985xaj55mlgxp9qcnc3yr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7820,7 +7830,7 @@
     }
   },
   {
-    "address": "erd1pfrnhlsvkax4vky2zx2ux7ay7pwzzdgrhrjaw8268swr5g7yft8qda4jss",
+    "address": "erd1szurm5r0h38rl58e8p25zvl5d868mcvn3078wrwwsfvyafk39xsq48srm0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7830,7 +7840,7 @@
     }
   },
   {
-    "address": "erd1t4j6qjzc3x2rcp8869edtr4206zk86wjua2l8w69kygt5vvv2ays4r4ttx",
+    "address": "erd19hd797pwywmvw2dl8gmp4clf6w6nxc7jykrsc0qxn2jakg3vjezqa9a65x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7840,7 +7850,7 @@
     }
   },
   {
-    "address": "erd1hu734dwkwkdw4atf2fmp7jhlucfalhxlqfashgh07tr06evprc9qs70fkn",
+    "address": "erd1pw96jxmcym8ktt43rl4sepm2ptt9fzyk2lw6ty9z6jgaz4zed2uq0zjl2v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7850,7 +7860,7 @@
     }
   },
   {
-    "address": "erd1e2svcqcvkj97s6f9enf0984gn80n9jgjvnc8hk9jfhlpr7jw5yzq46d3z8",
+    "address": "erd1rz5uw3s57glathskjts84fkvf3u70tz4xvrs2rvhem602vvnphaslk2yem",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7860,7 +7870,7 @@
     }
   },
   {
-    "address": "erd183fz0mk7mpxg0clf99tlfc7veela0wpnrwlr0x53g5sl2zsp44psu4n2a4",
+    "address": "erd1g53ed3qe597fqkp4jrjf8n0stme9lrtt5kt6fz7f9hd5rhe3lqdqs9a6dz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7870,7 +7880,7 @@
     }
   },
   {
-    "address": "erd1pqjuz8a76qrq0a5y6sfrqkwyytgljeghlgztewwlpyw3368rv7ksrxp7t0",
+    "address": "erd1avggjegcathndsz9ncjrpe8usqrahr8s4txkm3u4lzw5890r664qzu8lfw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7880,7 +7890,7 @@
     }
   },
   {
-    "address": "erd1m5xu7eay5c40375y65td24hdj2yz05l8hj0thc9nqvvvgxn5t5astt0h7c",
+    "address": "erd1eagca4qmjwnxdnmettrkqhp0cv5k7n85t4twal7n6ys6nrpcu82q4c75ec",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7890,7 +7900,7 @@
     }
   },
   {
-    "address": "erd1uexq7w03cz0r2crv6g36gqpdlda59twf7rqgyh0cyp9kxk93z0xqgzhj95",
+    "address": "erd1dvpnsaskww8vcexp3fu9tanznawmzlffe73kwsnzcxk74he9fe0s8agtt8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7900,7 +7910,7 @@
     }
   },
   {
-    "address": "erd1c2ujssthxh2gfwu8adzcjtr66fsj07vrd8h9l7qxunhhu9hfxapsnv6wsm",
+    "address": "erd1vsj37ckuqavecq50pu8gd6mdvl5km4rv8jgx3ynf2qmlc826z3lq2wkprs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7910,7 +7920,7 @@
     }
   },
   {
-    "address": "erd1fgs2qqrnut8zrdak56jlw7230glxkuf0j2y95k6tyye46vu7z2kqh6vfch",
+    "address": "erd1ylphq69ma4hww40nruzhra89m7nq4u286u2dj5xtz5ngy4knyt8qysvg44",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7920,7 +7930,7 @@
     }
   },
   {
-    "address": "erd14m4nykcqy7yz3w5afy9vp9jqvfwx369xq3rpgnq3ar9xa8msshwsjlt58g",
+    "address": "erd1pdsz9hczv27xdp0n2n53rugahrsz7jtnjrrnqhwl5ryz3d6h7l7swlvqg9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7930,7 +7940,7 @@
     }
   },
   {
-    "address": "erd1j780gn9ceflutwdt3d6sauq5ts7q3myz7kjt28vvqpedvqedj5qq82m2u2",
+    "address": "erd1nz2rzkhy9saq4x9jem6mkechud638vn75m8clz2c45a8pyuq7cmqj0ngjq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7940,7 +7950,7 @@
     }
   },
   {
-    "address": "erd1n35q653y97t63dnpqqt0d4fd9ksaa4wqum5xced74gmsukz3ajuqaexsmv",
+    "address": "erd10n605v4cjqc3a8hczz7uzy99fv3j0904smdugc8qmskt9f3qv6yqfh2n9h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7950,7 +7960,7 @@
     }
   },
   {
-    "address": "erd1wtkyhnrgjdd96ava0hnpcj2a38uj35dwndqe7lymu3y5k6h7pswsk6l2lp",
+    "address": "erd1v3ky80pc3ug63rgezu5d4mutq70764egj36832hxnaszg02sc8jq8scdp3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7960,7 +7970,7 @@
     }
   },
   {
-    "address": "erd1tl4c0eqs52umd8uyecjtlnk4f2rzp7l7pj064efa0fedwfl5s7zs00pyrk",
+    "address": "erd1ruhv7a0uuxf76wmfyqkvqyy98flzl2alm6s3zcc8842exmd9frlqtheah7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7970,7 +7980,7 @@
     }
   },
   {
-    "address": "erd177jd7z6tl2g838q6yjxxa2mkx3zn7mjthrum45rewn2h0rps0h4qsxzml7",
+    "address": "erd1n8rj4x2yjdshz7ak80hpjupmrfy744yv4z02czg0kxd2yltp5aysc2kefq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7980,7 +7990,7 @@
     }
   },
   {
-    "address": "erd1459hrsqc5jmvr3wvs093vpn3vv6qaheh7au0zpn9t5wa344zs9aqa67l0m",
+    "address": "erd1ldyq8gpjlkx95u7w6udgkk6c489qqhwfy8d206g2ut5nx4nt45msktguyx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -7990,7 +8000,7 @@
     }
   },
   {
-    "address": "erd1l64cd482st48pnuu4lyd2v5pwz8d5ncqdfk3f3q3swx8rrjgdxas075dmk",
+    "address": "erd1l6zh6h9jx9482ug744gt4j2vjlelvw5dkkchgm8j0vstctvrlcjsa2qkv7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8000,7 +8010,7 @@
     }
   },
   {
-    "address": "erd1us0qgxutzpgrqqp9whdcvv92cedj0vp47e2nghrcrlutthymwn9st93ear",
+    "address": "erd1jpdwlyy837dhhspdjl36yf7ax8ymnpn9vw955w0crduwvgakzhwqjyjugy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8010,7 +8020,7 @@
     }
   },
   {
-    "address": "erd1w9msys0vkrj0ncw895dtpk2s36glwzs0qhu7zhrq9804fyptlwlq6yc3ge",
+    "address": "erd1j6k3pcrd4ksn408f3am4tvk8nwp4tmw5kdqqwc0u792xscxnmvcskhe2tm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8020,7 +8030,7 @@
     }
   },
   {
-    "address": "erd15cfzjw4l5pjvy3gp6vlq4vj9c9u2v28ze6n440t5qzaml6df9c8slk0rjd",
+    "address": "erd1l7qat5xd6xrklstse6qd3r2jgup4ak4q2nnfwtysz452vqc084wqz0stuh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8030,7 +8040,7 @@
     }
   },
   {
-    "address": "erd1vjyl2p67uc3l2x0h28vafulzyaeutft63urckgh7m5jvmy5sde6q02sv4u",
+    "address": "erd19aes0d2m577e49k0cngxvmunwk2ygxhcse54m88ky57eedswxqzq2c6gs0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8040,7 +8050,7 @@
     }
   },
   {
-    "address": "erd1r0y0zjh5ny5t8qu4ld6ux88q3ewx5mlku4m4cnwcjv97ejlqwsqqa26sh5",
+    "address": "erd1erwyp0eylc37qu84rsp4ghuqf9cprufrd2jx87mcx9f4xswqnkrsr0qtgf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8050,7 +8060,7 @@
     }
   },
   {
-    "address": "erd1utmft5wgu7cpqlytyljnduz0ga2za8s64xcfeyguzkxrrw82852s683up6",
+    "address": "erd1xeffgmfj8ywh8v7ked3frv22nqe5wcr6gw2kjdpl3k226x3lg72s48rdf7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8060,7 +8070,7 @@
     }
   },
   {
-    "address": "erd1mh5vqw6hdak0xrcqg3y95d6srdp34yyc9yy8l5k3n6e7lmkexwzs6z6dyw",
+    "address": "erd1qmev5esdlgrqvlclrhflas8e4cfqzv009plkax0xs06w445lanrqz5k8af",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8070,7 +8080,7 @@
     }
   },
   {
-    "address": "erd1pp7t5mrxk5x50cfr0zh789v960rnx24j3pjfvww2nmscdh864zyq8lwl2p",
+    "address": "erd1je3an5gvh3cfnyp9p90j9ra8guks7upnmn8f0z7ysevpn52h6a5sy83fuz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8080,7 +8090,7 @@
     }
   },
   {
-    "address": "erd1r97vv380uh04w5pqzref3r2z6y5svhd8qlpqen4cqe4uytvha3qq9n4uec",
+    "address": "erd1kdaqvsg7hacvsu4sfkumq7zrtewz730sf9rnacqs4d7svvjyc5tsvgdflz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8090,7 +8100,7 @@
     }
   },
   {
-    "address": "erd1hamfk6xdsjzhmdf6ktj65es7dmq09cyld4jxuspm7p6wjc6rdlvqmfphjg",
+    "address": "erd1aq2e42pfgwp64ua95s0xs2ktz7j7p26eg8np4g9mtlnr3xh9wzlq7v7d4v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8100,7 +8110,7 @@
     }
   },
   {
-    "address": "erd1fsgdyk0w7ty28ge9p7n2pjhcs24jl932x69galsnm0x55jhf0awqk426ne",
+    "address": "erd1c9qxt3qzyu78mdhjem069zuq6ady5dmnhs9kjwctz3pjr7yf58mq2jtc0n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8110,7 +8120,7 @@
     }
   },
   {
-    "address": "erd1flkpj72hc6zchrsv2r4e9pw9g45vdn6dvwkjqja2r77aws9598nqtgsd5c",
+    "address": "erd1gp8d4s5n7ya64n3s5uvxxy5w7dg9vcahvqspfsqq6ht8fcra9klstzwh5g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8120,7 +8130,7 @@
     }
   },
   {
-    "address": "erd10x42m4f7up0kd7us24s5uhety8d9dhpd7474cnee9aqzpslkuras6na0zj",
+    "address": "erd1acsut5cecqy6gl6xrpa9ra4lurwsuk6apk6hxlvgssrj4zjmt3nszw95hs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8130,7 +8140,7 @@
     }
   },
   {
-    "address": "erd1jtx2pejryumt4s9snd9dd0u52he7fahujyms05vzaf8v6nh7m79srqn9fu",
+    "address": "erd19gx0l7ruxa4emvcyahj6tyy5he95jk8z555ugrakllsyyks8jr9q2dgmu4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8140,7 +8150,7 @@
     }
   },
   {
-    "address": "erd1ehkwdv7u5649wy6duwtew402w4t2x6vzy5s0wz8tfecdhh0prrpslf7jyh",
+    "address": "erd1uvaaz48mg7kurzl2gs6w6uxsetzn833wtng2lxe7ww3uyaxwa8wqzh8rrr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8150,7 +8160,7 @@
     }
   },
   {
-    "address": "erd13pkuy8lv0afwrd7472zz8qw3g6wkg2aar7jqc2et4glhsgdvfkqqzf5fx7",
+    "address": "erd13gkaj392cxqvhwh3k2mlxx2wyq7dm7ky023l4fkgq3dw43exnmpqstrwa9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8160,7 +8170,7 @@
     }
   },
   {
-    "address": "erd1n5g6gywpdwru3glwq8f4uupwy7zzdyf0gcx7u6f0y5uuglu599uqrtz4xw",
+    "address": "erd1z3afl2pzkm54s9xlhpx22uwv0ptldexsxljx9vr9vg3jzxlwd69qaf7njw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8170,7 +8180,7 @@
     }
   },
   {
-    "address": "erd1jp69meslvn6d29wr520qgmjjvgah0z263m4xr6ljstd09kucpp9q8wrs4v",
+    "address": "erd16vx9eyqdwucmj93665qw30la4jtnk6whsjfm7mcr4rrvhw4yg6gqx3c2vj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8180,7 +8190,7 @@
     }
   },
   {
-    "address": "erd1vd8keh07xsxxfll9t5dr7cktglclcpx8ef44qnc6y993el0k9cvsj58gcf",
+    "address": "erd1r4hh64az5alkqtufj4fpjl6juaqxs0d9xvwn8wcvd4697nt4x22q6put6e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8190,7 +8200,7 @@
     }
   },
   {
-    "address": "erd1x3nlt30gzd86f7s7scsl69ekeghvl7emnhx7jd2eyjp8dxuh505shwz8kf",
+    "address": "erd1jap0awhsc3u97rseqvrh9ma4q6srvxy2hylkgdc4qxl6dw5t79csqemd4z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8200,7 +8210,7 @@
     }
   },
   {
-    "address": "erd1090y8mkghec57accqhgmnmry3tslujvvkaj39v8u535yulsnktysj5zx36",
+    "address": "erd10qukapz54pzckrsd3xunwvlywswmdel8tcav24gweevzxp6s3kfs8p8t8h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8210,7 +8220,7 @@
     }
   },
   {
-    "address": "erd1zu96csfqtlx83jz08jw4rrwj0ansyxqy2dfuamn880pcgvkae59qm03xhz",
+    "address": "erd1s36fu2neukg3vwfwzmxek455pcq6ekdj4vpludrpxjv2mg96e6fsgt6fm8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8220,7 +8230,7 @@
     }
   },
   {
-    "address": "erd1lup35723pheldc90zecjdlc68mnlrcgjlaevchv4q70ytetgcvwqdkctpn",
+    "address": "erd129nudnsrruw6yuzng3jznc02pqel2jn86cx3vds2xne0zuqdwfns0af3aj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8230,7 +8240,7 @@
     }
   },
   {
-    "address": "erd185teh3m6jjrnm0cxk2hq7z455077dc5fhepenhvm88zm5gg4y97swvfrxc",
+    "address": "erd1alvk8cyurgpalhuy4u2tekggkhyhz9fylpmk5vyc3gxdg6g8h46qelhtzz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8240,7 +8250,7 @@
     }
   },
   {
-    "address": "erd1g9lnhyrhv5vfgjqxh57n8449z3x45ncc2f47556gekl9jn0fafqqcx4ugh",
+    "address": "erd14nsvnhslr9uzepf9echghaf4g494d37axhfaj4lgvr00g4uugxzsz3hv8r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8250,7 +8260,7 @@
     }
   },
   {
-    "address": "erd1992kssru0qz6dtxntvrkehaaycq6etztvl8ssgj5sqpkw9vnt76sg3lrcl",
+    "address": "erd1nd4hczznl54fhuwgzg4jahxvz43qy262hqy837pjvys7hhc7xfzsxpg84v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8260,7 +8270,7 @@
     }
   },
   {
-    "address": "erd1fremkwgmq63j92erghsd62lcxwrazr5clxmrrqt75sm7xjjggyyq502v9u",
+    "address": "erd1azeqc5wvkl257sezhfwphnxa9usymh0hhemycfrh7eznjv3xy4rscj4m47",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8270,7 +8280,7 @@
     }
   },
   {
-    "address": "erd15j008sj9v8yclcj8ju2qew4c88mepmrthjuzfzk3lsyh4p2lz33qtpleq6",
+    "address": "erd1ak4z4jm204xv2fy8sd0pxng64j5qxc8awl8v6sxlt0aq5z3tkmjqfhjext",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8280,7 +8290,7 @@
     }
   },
   {
-    "address": "erd16u8p03lfl7lwyehd9ll5pcfej5gcfhwelnze7xhh0a3whdqj50usn449j8",
+    "address": "erd17z3d4wua3xp6ajxa76a53nkruehapyggq3x76v5xdrfxd2vncchq0rgax3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8290,7 +8300,7 @@
     }
   },
   {
-    "address": "erd1fv2cs3475t0xe3fsak63s46gedp9zqlylejnj95764c4950ug08sula70j",
+    "address": "erd1ph8y7aa5r7hmgpalu3f396kjjvgmz0sxuy3mxjd69ajzhcl7x5vqtj92y5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8300,7 +8310,7 @@
     }
   },
   {
-    "address": "erd13paxcl6cyjtlj8y0scdnh0h2jtmjcpn5nsceyzfhp2jhf8h0jtfs69vhcm",
+    "address": "erd1tnfrdnza46zxj49lsasndhht78ruwz4ykmyxvuaacyk2ggf4y4psswh49n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8310,7 +8320,7 @@
     }
   },
   {
-    "address": "erd1kecr46dp3l0vvydwfnztus94c85y26u40h00k4m9a7hwguprrlwslucdx0",
+    "address": "erd1p7lzyqnjd89pspj9rg2p0utf6y4vj2y58m9tck8ryp7t02fgcknq0pcu5w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8320,7 +8330,7 @@
     }
   },
   {
-    "address": "erd1es9jsczmyrd9afa7gzn7zuq9rvt3swqqtun7j60ydaecawckwrrq6q0f8r",
+    "address": "erd15dym6djn6z7j06txulrvz6q32l2jaefl0fpl545paskaq89y9vcqavf3cj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8330,7 +8340,7 @@
     }
   },
   {
-    "address": "erd1auefwy6gxdhr54x8pjhk962rydzufn58mw5n6cjxznqhlzvr0t9qtgndaq",
+    "address": "erd1h6smsayrmup3zkwex6fnghqh35k7m3u8ja4pg9pxlnmhmgfs6xaq94madw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8340,7 +8350,7 @@
     }
   },
   {
-    "address": "erd1e7tretnr609nm64nfvwrz6qhzlq7rw7m95rw73nygplzv233dlrsvrnpq4",
+    "address": "erd1fzmdfutq53zfcl32tjuukkxkpxsv8zsarvq52yrs6s7hk5vadtfs7kp47n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8350,7 +8360,7 @@
     }
   },
   {
-    "address": "erd1s88w2x7l07ujuqgwx5nvdenjf62zxdtdefghx2m84ch8zzj7de0sej25v4",
+    "address": "erd1he7ppx8as96yyx76cqeex5gkza78xjltucxgpxfwnusr66ta7xfq5uksl7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8360,7 +8370,7 @@
     }
   },
   {
-    "address": "erd1jw0hpt0rtyfz0pa0m4scuht0vkaa5w8nhjnhu7mys9xzlkadslmq2tqzz2",
+    "address": "erd1cfhnztv04vwjewl7ms35jz4efqmmyg7q9ganm3nlwmcd4a55qkgs85gdrj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8370,7 +8380,7 @@
     }
   },
   {
-    "address": "erd1ghcchh4hgccx7an0uaefhypfwwrjvt40320chtfe5d88qtn0kv3sz47yhz",
+    "address": "erd1lvpalvwtv4fd360h8swtue79j5l65pg82k66f00u6ku9veu7kjdq2w2f7f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8380,7 +8390,7 @@
     }
   },
   {
-    "address": "erd1jl0dvglaepfs7lp9wql9cj0wkgztlhyh03zsq0stmahanyukj9fsy9apny",
+    "address": "erd1nhw9uyd5las3hctu7kxpalsft3ck8464jzmk4d6rjajq26lvxctsjaq8vf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8390,7 +8400,7 @@
     }
   },
   {
-    "address": "erd163nz02f2d3h4arhud9txdcxzfhqsacq076qf83hawjrt0p4umvjs7nsqh5",
+    "address": "erd1a2vhr35rfry0hnx29wzgaqtw5t08jj9py253njvte6ua8vlpnxuqa2jmhj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8400,7 +8410,7 @@
     }
   },
   {
-    "address": "erd1cll5fs2wddngernkcxn2v7hkh0e9wkf96mquwz03vg8g0tj5cffqr7h94m",
+    "address": "erd1yra59yansdasmnnsrc02e96kwz48z33gfv5txdw8ahl0j3ez8u9swg0h9p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8410,7 +8420,7 @@
     }
   },
   {
-    "address": "erd1lfe77ugpf25w4ndzd4fa0knmzy08tw0mnagvpr9e88mt4pr4ry4qs9l8pj",
+    "address": "erd1zv3za0sk5emfdwy88y22rzc8qmjs24hjgv2qkgxt4jsv3j4ua04s9xugkf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8420,7 +8430,7 @@
     }
   },
   {
-    "address": "erd1e5uxlupmyntr9fnscxmjd894lckks48wu2cqrcwmf45gqgfjkcxqpfumkw",
+    "address": "erd1kuk3r23clwm9xc4qm7lv78aaugk393eldz68nx8pcte5mcxpqc5s9vlqgt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8430,7 +8440,7 @@
     }
   },
   {
-    "address": "erd1x0qcw7mqzswmdpzlnhd7wy2txef2s3u8fh22w36qrkdnsgulfj7spd6ur5",
+    "address": "erd1d0wjulfg43xaflmma7xew8etsyjjjjvylq7pf6ukyvncszxcal2qmmkscc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8440,7 +8450,7 @@
     }
   },
   {
-    "address": "erd1y865ms3t3xeapegqzghkesjhj53x054cnkkhntjq96u975cltrsq45h63p",
+    "address": "erd1clzcfk0mqc8ragfcqcvg4hjufxwh96glxh4gdxlkv0s9ra66ueyqfqsesj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8450,7 +8460,7 @@
     }
   },
   {
-    "address": "erd13wwu3637zuteqzkzja2k5xr4pgv425hz06la9x4k8t7vcqz60p0s57hw62",
+    "address": "erd1ve6jzge9vepqwlykyarxqfvs0jam495s3t865k3v4extz9qkzqrs6xxyn6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8460,7 +8470,7 @@
     }
   },
   {
-    "address": "erd1xxhunktqk4jaw0y5mkj330tvlryrf2ccvmttd49e9d36cncmdp6sjwhvu5",
+    "address": "erd1k4lnknpapm3j5w0gjms337dvrrn9hnu59axvge8ucfv74sjn9u3q2ksdc7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8470,7 +8480,7 @@
     }
   },
   {
-    "address": "erd1hjgeu7p6mgaqhqw64mkqhu24uzptf0mv735xt0rxzdzlxmg52jxsdx382x",
+    "address": "erd1ywhcqe6gqzhuq283mcc5484sy9xjnzsukyw22gcd9hwpvtenvdfsy30l7j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8480,7 +8490,7 @@
     }
   },
   {
-    "address": "erd1lm4uypklthp4a6fe4zkd29z7rvrhrmnteappyyy39fjzsmskvz7sqrf7wf",
+    "address": "erd1r844x8tvtl0jthfrjmqrsvy8gmeudx54y4skfzc9ds2qppk3xh5q2an3mu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8490,7 +8500,7 @@
     }
   },
   {
-    "address": "erd1df2j3rsgxeqemm0e083e004w9dsun7tpfafejru9w6jeqy0yqfuq9dfdx7",
+    "address": "erd1dn0schq74xfcyleew0n54q50mdz5l8c38cettskae0tx0wanahcq3ct0ju",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8500,7 +8510,7 @@
     }
   },
   {
-    "address": "erd1lg4ut8jxtml4k705suw4vqjtez7d7lj75n6favm69e84lrrpkurstjhk82",
+    "address": "erd1kgs0t903ega2rvygvxyut4j3qzc2za3e2va083rxz46rv5j7njlqv5g90l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8510,7 +8520,7 @@
     }
   },
   {
-    "address": "erd1f6uf7c2zmzwvnyzazh672j7jq0hlweylstdk3zzlnrnq5nlexezsm2xask",
+    "address": "erd198ecac6xfsrdlewt07h0hn3glcdh4a6k89lyg388jyumjsazlp8sprxmse",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8520,7 +8530,7 @@
     }
   },
   {
-    "address": "erd1nwthsxvjmuxrj9sy92n8zl67s6gfqahqqwzgz3gcwvdr2phlmqnqvh0gqx",
+    "address": "erd10z2a2nhvhka67uw09khtewzl3d6tmg3hzxgr7gck6y55zjmggxssjvdrqm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8530,7 +8540,7 @@
     }
   },
   {
-    "address": "erd1hepgglpwl7vvafdg6shjre5gnl32rmkw6lkws3nvnsk6hruygd2qj3mkya",
+    "address": "erd10rjy98m0d3pcruj4kd7h62jehunm0qy522mvpyhffdtpng89e5vq7uf9y7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8540,7 +8550,7 @@
     }
   },
   {
-    "address": "erd18hfmev3wr6m0dylmajv5aphwz8jdhsvnummt57qhccvylypxwynsnj4scu",
+    "address": "erd1w64h497zmc35z8lz77xwrg2e4x25d0x3kkv2ntx9yzgm6kkw70qs7pxce6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8550,7 +8560,7 @@
     }
   },
   {
-    "address": "erd14muuuv85aetmammymnhevuc3ckeepg9thgjcjv4sn4je3g49k3wskdujrn",
+    "address": "erd1g5ujad7jyvmjq3yj9hx34x49as6zye6k0c9jgw4gqrtush6vpvls9g9y65",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8560,7 +8570,7 @@
     }
   },
   {
-    "address": "erd1cu9a2jctv03pjazs4dlc9hp72sh3nf62g6wkgu080slsk8h737nq2ypx0t",
+    "address": "erd1w42dw5rmw8dlnl9w207548t2zpml6j2refhhtylp8dtzw792du2qg7ndph",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8570,7 +8580,7 @@
     }
   },
   {
-    "address": "erd1ajws4xqsyzjjlvcj2zekwm24dfsf4x9q7twfasdttgn3rqzx32dssj6gsj",
+    "address": "erd1eepx04taethd4v0r00mxywfew6234qhjtekfucetvv6crc88vxeqj4858t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8580,7 +8590,7 @@
     }
   },
   {
-    "address": "erd1nsnfjeg803v45gmrhfh6ggejyej9mmsvudgcwuf84j9xscvxtk9qs9dz2n",
+    "address": "erd1shpa3t37sd5mk2p3uw4c4mjqdqluh7kl2gd0p5g2ltu2av03k57sfazyrm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8590,7 +8600,7 @@
     }
   },
   {
-    "address": "erd12ands0xn5309durhlnl0wk9gd47qxam9lvkrv9hf2xvrg20effzsjw9367",
+    "address": "erd1kcc274aq53w8py6v9zuzv7ku7e0dmd6q53hz60gns63f9w4utzcsx5wf2h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8600,7 +8610,7 @@
     }
   },
   {
-    "address": "erd1z6ad939529666ft05c0s2yq9fa24gzcxlt4nt49vs63dmej5s43sz5qhte",
+    "address": "erd18err5q9yk86jtjezm6nxpv5457npqmama80mawhruvgn82e0j52qk4u3h7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8610,7 +8620,7 @@
     }
   },
   {
-    "address": "erd1mr89dzfpvcydxx2kplkmdtqxegg4w2mhwsfzyfll79rx8kh8465sknwerk",
+    "address": "erd1ccnhql082706k2yvvr4axmwpclcqzptwfngqm6kcsdvtvhczm3lqn6l8rf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8620,7 +8630,7 @@
     }
   },
   {
-    "address": "erd1w9hfn43ux5cxa9mw3zyxund8v4wdlhm3kvammlqfxregq8htu22qlc58dz",
+    "address": "erd122rpyuvx4dx8lu3z9x2v382qhghykj7n3v04ktpweykehcrxldfq6mv8px",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8630,7 +8640,7 @@
     }
   },
   {
-    "address": "erd13jldq3yjs9ezn5fzczr7f3tdut6xgfnc08339t82k8u5hka0apqsvcqs7d",
+    "address": "erd12mxu0fp7h0xqwsvqa4nwqpcycr7d5u9040tr0qmekkmplvzzkymqh2rzk7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8640,7 +8650,7 @@
     }
   },
   {
-    "address": "erd1cudl88t2kcs8mwd78dga5dz2dh0hxn296l6slah2fvruvk0y47psdtpvuv",
+    "address": "erd1ujudn48hr29px02rlsjtas9z69wlxnmdkhmuuh8qgjjjq4a456tqd8jpjd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8650,7 +8660,7 @@
     }
   },
   {
-    "address": "erd1uxpsmvgc0kch8hdmpsm5yel35a7vx8ru7stld3h4u9xunmvh46vq7s377v",
+    "address": "erd1f8r0ve2kxd2yhfk3e3z2n0j0uglzszl3fxx5fs2z39w2cd5taffqw3rcfm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8660,7 +8670,7 @@
     }
   },
   {
-    "address": "erd1gcyhhy03vgxwaw6r8lns87xk8t580t450pqnxapm3spa7kf5g84q8f2zw4",
+    "address": "erd1mygz3hj3m42xqpluehyn86jydvshmy2gekr5ehus3vn50heyqursrnfm45",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8670,7 +8680,7 @@
     }
   },
   {
-    "address": "erd14zn0wrjg0a9tfpmjm4mm6ncjvw8cmjmfl2qrrwe9frdh0e72e6dsdxqw52",
+    "address": "erd10vanepp59eh7zqt8kjp7kwfld35u7mmxdmyd80pm7fw23yevpresnkq3rc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8680,7 +8690,7 @@
     }
   },
   {
-    "address": "erd102h66f0cm6zzfg3fh3l7mefxryxm7gru0ewn42caypruvyty6ulq2mq0g6",
+    "address": "erd1schhsa8ys9fhu258u7plnhrhtvuyz3xddnkd2empagcjsn59w59seg30zh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8690,7 +8700,7 @@
     }
   },
   {
-    "address": "erd1pdr79yzqm943rwhd6f4au8hzxffu3sz36j3k84qn4gll6awk2z3qxljjrd",
+    "address": "erd1r0g34fpue6y5p50ff070syfpdvl4krlg0qa0vec7fhyhxxfzkflqer7jgq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8700,7 +8710,7 @@
     }
   },
   {
-    "address": "erd1fga8xhv2fc4wcgsykn7xpewr4pp6cgjzrlqlrk395drulrn4syfqkr5dul",
+    "address": "erd1sv5q9yd52z7npqgfant4h4g8p6fyql5ax5t8wylavzm3reqezj3q0d2evq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8710,7 +8720,7 @@
     }
   },
   {
-    "address": "erd156f8wh5kx00zz6w8kqnkegpyyta0j0wghr23kv6gq3pzl996q08stxsc0l",
+    "address": "erd15myw77psr0w7sezkepdfu62c449tnvwj0gf735hq66yfvacwm99qk3ewtl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8720,7 +8730,7 @@
     }
   },
   {
-    "address": "erd15nsldnjw363ph9rr26tm0wnl3t3fkrsj0yr5ta986vnl0dr2w4hqy8erky",
+    "address": "erd1fs4al6wwtuhwvtmrpgma7k4en60xnd5l7tfcnp9auf70cua6evpq32pdsg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8730,7 +8740,7 @@
     }
   },
   {
-    "address": "erd16e0q7xs5jjqrmljklr7wsyx4cp5q4mprepkqvkjtxksvrtq992dqavxus7",
+    "address": "erd1h97y0268393gp70nvgus3pmh6nz866s0r6qeqs9lr2lq4aak3qssqa2s45",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8740,7 +8750,7 @@
     }
   },
   {
-    "address": "erd1nwwvgq8r86yjcpncc30hz6v5wdqxggaht2jycf6aun3wx2uxthcqhyqdkq",
+    "address": "erd1skj9uc88xlhqdxcqjnx2h4f9ssja2jtgpdxhdgz07cpxsspppeys7jzsnr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8750,7 +8760,7 @@
     }
   },
   {
-    "address": "erd1chclnzsydywghn07tzjeukcglk5vq0rd4h9x49lqn67gu5e7r4sqlr6gzk",
+    "address": "erd1lrnjzag4c07gjlkz4ahlz8f6t05fqhtnkvu6f86dpxtxp32tle6sw282kk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8760,7 +8770,7 @@
     }
   },
   {
-    "address": "erd1ksmfgzkurwje6tm3xfzcn8cfny4p4fkux6tqplrve77jjyu56x9sj2wp6l",
+    "address": "erd1espal7zqnpy2de320200pxfzkhdudt659fv0agyz9zn898mkh3uqwqxsse",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8770,7 +8780,7 @@
     }
   },
   {
-    "address": "erd1a047m3cqxttngu2hd6le2ns9w4kkwvz80f742ad2dljprxd3t09qnldc27",
+    "address": "erd1y5cgvt7r0zgcf0lmq8wpzxxz5gjzfy3r829hghfsugpsquyk9qqqss5hd6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8780,7 +8790,7 @@
     }
   },
   {
-    "address": "erd1swr2m454d2cxwd9y5dq6ysmp4suk6m9djwlgympj8qx24nlmff2sq9893k",
+    "address": "erd1y9ef98r9xmwcex6hu3wyy0wmm7fx7rxsqt78l0glm9c44y923dqsfenzt9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8790,7 +8800,7 @@
     }
   },
   {
-    "address": "erd1nm5ne5hhg7ncg023qara0z50dayjjyul2a0u2atvv29uh5rx646schaw9q",
+    "address": "erd14jashfzv95z0gyrasn8wkr4qv9zu79dhy6c5m77alh3049vduzaqxhaycg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8800,7 +8810,7 @@
     }
   },
   {
-    "address": "erd1awlsv2kc96dt6h2fhfywpk52chchd2czs7836kcmk0j7687mve0s8zgh99",
+    "address": "erd14d7z7s4n8h5zr6s5m5tgycqs0ff868w38y5rc92t5ur8092zhnuq203yn8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8810,7 +8820,7 @@
     }
   },
   {
-    "address": "erd1z7tqxvxc4xwkadddpz8usru8tp955fddg5hmt8rynm5zz9838xcs50nzld",
+    "address": "erd1m75355y6hxchp5hf6ppdqh6fk7pvxrayv9h6ckdx925mvdsjpleq99trpc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8820,7 +8830,7 @@
     }
   },
   {
-    "address": "erd1ylh58eu306cv4mnqgd8u28kvacqnex30fd54z972cu7m4pelnkqsjz6qrt",
+    "address": "erd1e07zm69gkcd7r6xvtmv5d8pt7mskguhd4fejqj4gqnkfu03s9kkqxxvr98",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8830,7 +8840,7 @@
     }
   },
   {
-    "address": "erd1j4cvcavy8hxxvvaspgege03fje4lzwxn0rywghj95z3h8dh988usprqheg",
+    "address": "erd1tj39882mhlka0dklpwdfy0yw9mpesgrt4xe9pzr5leayum0tck9qpld4dn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8840,7 +8850,7 @@
     }
   },
   {
-    "address": "erd1c7xw6sgf9svsykgwrheadzxxy8kqfwv0269fkxrngqq6dec6f3js9sz7w6",
+    "address": "erd1xhjmelxdx8552vzqwcrkjawqfnawevxm9q5ze88pvtjuwqvmx6ps0e84cz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8850,7 +8860,7 @@
     }
   },
   {
-    "address": "erd1l406sxh4yru787gseuqevymchq47zh4dqdewd8c0faadlzj8dlasdv9srr",
+    "address": "erd1p2jd6ezvg2faaktuueawja3p0klygdeuc74v7q96e85207j0z2hqw98hlq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8860,7 +8870,7 @@
     }
   },
   {
-    "address": "erd1mwutk03zqc0pqd6xx7hur2tr9efm4w5dlym4mfcaymj7u8up2wese5y5g8",
+    "address": "erd1hn5zjg08anhnk20hvmfh7p83shyzy052d2kmxp95y4h5z89f2w5quhryfw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8870,7 +8880,7 @@
     }
   },
   {
-    "address": "erd1s5km8r8v2rm3tw0s8um3gejtfa70uk26pqjj79f0mr56fp24uswsstxuzv",
+    "address": "erd10eccr3mtatrttmnxgt0nljfkpsue0hsmplf3mqpf3e5dd0naqtqqqlkc4l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8880,7 +8890,7 @@
     }
   },
   {
-    "address": "erd17umsa76t5qty9ny22m2y5ght9fsu3lpxnerwg8kfaawrasakdwcq2hlhdp",
+    "address": "erd1z4h242tsvu39mzjwpa2mslfpaean068a254g5ak2n6jfx0x9q7rq2ews08",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8890,7 +8900,7 @@
     }
   },
   {
-    "address": "erd1dd4ag090wegj67w6zy4a3n6v4fk5x7qmdyt242qt2722vc00wk3stgqmrq",
+    "address": "erd17ct765zqx7sus4jaytffhkt5dwkatd8rhdj5xqtnpl3zq3qqk7qq64nugg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8900,7 +8910,7 @@
     }
   },
   {
-    "address": "erd17aphwc2gfnjpxnc3uy5u443nc9uka8f5vezve78dah0kuzhqxmvsda5f4j",
+    "address": "erd1wvvlqz7wc8r35a3ude6dg3l3nr4n3lxcu9jg58pkp48m9m0e54wqegenu7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8910,7 +8920,7 @@
     }
   },
   {
-    "address": "erd16dpnc483e5kqyv205rx3d8ctqc8aezl7qxusagpqj94najvu456qggvqjq",
+    "address": "erd1hcdghpceszd8w8ukf7z49ev69qf8z5kjytmqnxscszyaxvgrk45sxpu2cg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8920,7 +8930,7 @@
     }
   },
   {
-    "address": "erd1tuj489ul07dstrl2gdgqalcrcw47r3lph9uk722awmpl0vuy52eqnnywkn",
+    "address": "erd1a0m34h789wdt5dxfawz7g3qqepj8j49v7t3g5lany5rxgypcjygqn6jkm7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8930,7 +8940,7 @@
     }
   },
   {
-    "address": "erd1amkn6m8lkjca9cnygkwk0nhn7getvzm2jtp9lk2wmnl4cphm0nzshhlekn",
+    "address": "erd16m23fwf2xe2w0ssyluyexystxl0zkz4qvmvlasvgcfjnhca6mdxq3t37mq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8940,7 +8950,7 @@
     }
   },
   {
-    "address": "erd1akjx9t83wn2p8mak3a8nx7cdrujmcs93gqttedmyzmqvq66gnu8qte4xlq",
+    "address": "erd1xr5sw6sldmnh2kh7l03fsd9s8ughftjj78q0aw0zhwc2edfh2jxq7s47h3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8950,7 +8960,7 @@
     }
   },
   {
-    "address": "erd1ugjxchras6d3tcc2rgz2jcmt4yfqy7zq5hn0nne7r3yx6528kuxqjgw7na",
+    "address": "erd173rwpehl0575gqm3cfwetutw9qpcz9yea44j4zg33kt05h2332zq54ceqf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8960,7 +8970,7 @@
     }
   },
   {
-    "address": "erd1yhyaevys5sy2qm06ymlxnmfe4rl2ur6qzf6eglmcfkwnaslt9j2s0kvh52",
+    "address": "erd143v6a34nyy74rl7azhehr555kq9cu3f07z644wxu22447e6fx7rstae2w2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8970,7 +8980,7 @@
     }
   },
   {
-    "address": "erd1hwz3d6dvy6r4ux9xenf7csga5h8hhpwscw60awvmaej2nlqwwe6qvz73rh",
+    "address": "erd1k3h0sftqvs4xdvpxxa2h5ka4pf00dcfr836qf7jnymef550z6vvsj7f4m6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8980,7 +8990,7 @@
     }
   },
   {
-    "address": "erd13qrdyfgd7y6exvkuufqp7srq9zgy2mr75pv5cxwmugw7e0mdv84qmxs2m3",
+    "address": "erd1j5hadust07acrw9jynvz2p0tgfptsvucrryjp7nex6azz78zw9uqvk40yz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -8990,7 +9000,7 @@
     }
   },
   {
-    "address": "erd16jf279e2rduxfryqy99503ldrnduzeh945at0hn9nrf39l6kxtqs5tph8k",
+    "address": "erd1re9c8h3ang5rzpj5fw3zlhjac96fv0d080atgsthcvh0tg3u0hgs5en8fd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9000,7 +9010,7 @@
     }
   },
   {
-    "address": "erd1h5n3l4rxw2q82szcp68k9had22xdhrn20jlxeet0gle0qm6gvt8q5gsxws",
+    "address": "erd1wfzk3d09jlgqexp2g7drezxj0ggs9gzqqwgqr8wusz6zcdy86yesekqu3t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9010,7 +9020,7 @@
     }
   },
   {
-    "address": "erd1aqs7ec3esplcmm3hycx8l7x89jurmhvjfsz8yn4gxw323yc94s3suejcw8",
+    "address": "erd1au6xqryumrjx869ykryfx0jtjeksuzq73muqdgactwenyvagtzjq5ae2c3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9020,7 +9030,7 @@
     }
   },
   {
-    "address": "erd1tumf69pxv9c26kzpf300tfpcdawa8zs9uw7n0ynctnfj79d2925stp45zf",
+    "address": "erd1j78mu43fgakct7q3cucs6pr0j29wz0np0gjz29gj8xx6nr4rsmlqxtrxtc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9030,7 +9040,7 @@
     }
   },
   {
-    "address": "erd146aqcpzrvs2yzuvpn55j48r026m4nfsn4qqthzcv5p2xmkckva8scm4sdy",
+    "address": "erd1jfc3pfl7t6wnfsjnrrzmg8sj7zcyem46atr8j0w7fwu2pl93qxws4r0s8q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9040,7 +9050,7 @@
     }
   },
   {
-    "address": "erd1hqztt5t9802gggy6jlchesmnwa3cqljpa5mmdg474edxqpdacgsqh88pd2",
+    "address": "erd1vlx2ggkgrd3fatuwh00yhjavkdffukm4xn5dtp5kswqypc7yhrnsaafemy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9050,7 +9060,7 @@
     }
   },
   {
-    "address": "erd1a89q56c5z7qmwagy089czuqgpth3kzggjklpqxmpxpe3c7jwdglsfkxc07",
+    "address": "erd1xcz5gxpufpgghj56lf7dzcpqm6k622zc8crn5r9st6e9j3yea6tqamz84c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9060,7 +9070,7 @@
     }
   },
   {
-    "address": "erd1kfg0ef4qupv2gpnldn2cuh67c0rant9u0pvfgnnkdl7yp8cmdams45683q",
+    "address": "erd103dznsguhaa003vrznt7kggezxvs8yp3uyj9k553ya0az8a5vd9sme9q30",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9070,7 +9080,7 @@
     }
   },
   {
-    "address": "erd1ldm3rjhkt73t9e0pcm6sg7tedzjxudc5659vauxwks4gufu3x4cq3j6hff",
+    "address": "erd1cdm28q6eqgmrq53kcwj7s9fmjxuqpzlew6t9fgh7hx9dnmqy9dks2m2kf9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9080,7 +9090,7 @@
     }
   },
   {
-    "address": "erd1dsmp3cz0cfqau946e6s9shyulp5krqr28s007xwnhkuxhwe425vscrjcnd",
+    "address": "erd144l3u8hwg7kfj8yn59vz2x57a2wrx8c4g3n7x9ejpzwfsc9lfj6sgg7ee4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9090,7 +9100,7 @@
     }
   },
   {
-    "address": "erd1khjyndfq9w4q74ssekv83m8523mman8y66qvy4pu736d369kl5gsmxlraa",
+    "address": "erd1ag9pcaj2xfgy967p9g9gw0dkvvmwzmvdzct7673f84lz2c4py0xqr6zdc5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9100,7 +9110,7 @@
     }
   },
   {
-    "address": "erd1x42knr07mcn6pzmcfacd5wtu6pl4esj64n5yqz5255d02a6vkjwslujqvr",
+    "address": "erd1jsa5u2jwyrfkxa5j477jqgyjk62gpktyvwvaj7g28jekvchn4cxqw7dzwd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9110,7 +9120,7 @@
     }
   },
   {
-    "address": "erd1npt2s28yfp5rumsesa6zs0ke6mjzupgwm0tpzykha5fxvkkk83askcse7w",
+    "address": "erd193cjpxevcpkzrfk5wmw2munm5qlf5w4kh0qhujups3kq5np27ges23p8g5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9120,7 +9130,7 @@
     }
   },
   {
-    "address": "erd1w4wc7u5jpyjherwjxyzget6nqm0gk3fjgd9zrm5sg984svn69gpqhv6d3z",
+    "address": "erd1zr9fq2kh0qpsdakvjd73z6qyna2kzhyurkayf37mdq5kumdchxjqws8xc3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9130,7 +9140,7 @@
     }
   },
   {
-    "address": "erd1xfu60ccm6uuvq48prxygunwjcnwvn9zsqyk7w66y4w4qgh8jjxqs4667e2",
+    "address": "erd1zt8ye08uh4ca7w60vng5t7xup4j7g0pk5xu7vde093snkj5fyl7qf7vewn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9140,7 +9150,7 @@
     }
   },
   {
-    "address": "erd19w7w725cf6aukzzecgkst39edzhj3q4u2u9ncsshudtrm5evq9ds8umt9y",
+    "address": "erd1kcujmm2vvwq3hgs5cqa32xz4sat70x7dl8wd0jcutwq0xdtm0j6qul47zc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9150,7 +9160,7 @@
     }
   },
   {
-    "address": "erd1rwzcyq4tl72s4fww8tpxsa6kv9hfgxj7hzwm4xkya54t783w4tlq5yz2qf",
+    "address": "erd1xh57fws6hlj6vty83ue3a5wahtc6qe7f09dnmapn3n7ycw09shas0j22gu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9160,7 +9170,7 @@
     }
   },
   {
-    "address": "erd1eceh8ft2f6zrwwff3lzmre3h8pfdmwmhp4xyth4yvlw098lu2qaqlehayz",
+    "address": "erd129qmja95z4xjrxplt90tn9rf9jpk4vlm8hpp7tuf3jr098eq7z6qvlmv5h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9170,7 +9180,7 @@
     }
   },
   {
-    "address": "erd1g7tsuu389dlt0xvqtdf4r6yxyve95s94h9h6rhhy9mrp90scr95sydkpvl",
+    "address": "erd1hwsevafd9j6agrw7vcwpw7clurx50zc4dnkp6a2t85ykelep9trspx006l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9180,7 +9190,7 @@
     }
   },
   {
-    "address": "erd1xfdumvuqku0sn6xqz8xxymap5uxu60eeu05xugdm5z6vgq8t8t3shd90jl",
+    "address": "erd12xj6e5u0emqn5mwf8aa2y7d4rl2m6gkasahrgz38fyjc65zajkzq8nm3zt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9190,7 +9200,7 @@
     }
   },
   {
-    "address": "erd12yn0mqx0kephkcv3aqvyhvmqltu84dwxr6sq67jdrfmsjh2l05tqtd7aue",
+    "address": "erd1hmkaf7hsyjuv95dusve73guss7sl52ytmmurp0jzr5nqkdg2rves9r637r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9200,7 +9210,7 @@
     }
   },
   {
-    "address": "erd1m8x58wvevzekd77209ny3kyqg3nn8wqt0xjwdh0dpu4dlgc6r6pq2un6g4",
+    "address": "erd1tpzjgk0x7mfjphkv6tttd9wv59huljr6tz4avqgkjkuw938vt2rspkwdsy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9210,7 +9220,7 @@
     }
   },
   {
-    "address": "erd1u5f54tpqv5wj9kwnn6zh8gc0ms2h9mjc3tj2gu5wzzt3g7tgryts53wmg4",
+    "address": "erd1wnc8gaqv8vetppdczts2nez72wwnjculmusvrfzqe5vg96nhgfpqv32mxq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9220,7 +9230,7 @@
     }
   },
   {
-    "address": "erd1pftf3hhg04j5m8yhrhdh9pqc48nf03zdvzhjw0g9u4htpjppa3qsa290gj",
+    "address": "erd16lrpq3txyk27tfpagwwjxlzdvl4aeqeyz7frxzp3w70rjuhxkxhq52espc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9230,7 +9240,7 @@
     }
   },
   {
-    "address": "erd18028zxpz04vhdd2kk0wr3cmk4y0wrhlhlkps33zt2x2m53fjs0cq6cmqyk",
+    "address": "erd15lhfv2e6asq2n8jd40m3c4g0md4wh050550wcrd0ctshqrhq85qqq08nhh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9240,7 +9250,7 @@
     }
   },
   {
-    "address": "erd1zpzduvymmqkd3a0njxynqeaexhqpl84k8felvjcp6wxrwddjqzssr7knwu",
+    "address": "erd1723mxrvj906auc9due8cj7mk5zr3wf27sfddz7cp6cp4d70604jssptjes",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9250,7 +9260,7 @@
     }
   },
   {
-    "address": "erd17zqmm9w6qddhqc689mqzvzamffzl2ehju5026gwlcrps5n50jw7q408uj3",
+    "address": "erd1678va3empd98ndwgak6qln999kxcsaf7elg50ujcdzf8rmt0w6qsuexknc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9260,7 +9270,7 @@
     }
   },
   {
-    "address": "erd1ztyxwjjpx0ndjr06zwz6lxfp3vrcadsu83n2htlmghetaqunagms3ec2r7",
+    "address": "erd1hxkzclydwxnku53u3nny8egrd3fl2lwmvmhydhwzccxfpnycdudsc26wy0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9270,7 +9280,7 @@
     }
   },
   {
-    "address": "erd1q5r2dmpdddgfkfszxj64ja4w8hxa6kuvn84upzcztr7za607d6msyqwpzs",
+    "address": "erd1hv7sxjlzzwk4hz55lfzckla2xgwyjsa6wf7nqnmmtkx08ku9xf5q3t9zlf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9280,7 +9290,7 @@
     }
   },
   {
-    "address": "erd1jjyyu4jgukfzrhyfufy7u4az4gwxt9mamczq5du5pkwdqlypqsnq6kk52d",
+    "address": "erd1lq9wtahwpxxelrjcezf35da45nq0w2z0rdj0s2qkr4c9jcskl8cqddzk7z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9290,7 +9300,7 @@
     }
   },
   {
-    "address": "erd19rf0ezdx3ejr59yj8nz86j5zj6nk9zs937yd68ftlp7heg7dselsz2drl5",
+    "address": "erd16l9mvhtjeppdgzy94tz7jz0clwvcq8rs8tdpe4dzmumxw93a4lvs8wcfv4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9300,7 +9310,7 @@
     }
   },
   {
-    "address": "erd109ynngn2kytmp34k9mafqpwy66tc5zelxfalkdhhng2zss97pvmq9zxjfa",
+    "address": "erd1k7fncgzazwwjprwc3z6jgdju2jd3g8me0arpcc46jjhya3alz43q856ymm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9310,7 +9320,7 @@
     }
   },
   {
-    "address": "erd1940fdcmg8rjh2ra520aet4cx5ea5k3qze884dvvy7hmsnx7wkc2s7fjer2",
+    "address": "erd1gklweeyczyte8vyddgnszmfvn08jdefe8l99mlhcyy59anh6mlusk5jvm8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9320,7 +9330,7 @@
     }
   },
   {
-    "address": "erd13j8rj0vcsxtpxzk4cxef88f0hjr4d8tjz5lzt80x4phkyqge586qt9spgg",
+    "address": "erd1jxslm596xd5q5rs4xlnv2mn8svqxtza56wkcx7crw088m6cehyhq2tq4dq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9330,7 +9340,7 @@
     }
   },
   {
-    "address": "erd1dhfgltsw6fe2rakzx06efpvr0emsp52zl399mqnngst2gwxpakxq9p37c8",
+    "address": "erd1tdlhepqjk3mqxvzc5ucc8wfmpmyycvu7kew37j5a48v9520azsvqzug99q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9340,7 +9350,7 @@
     }
   },
   {
-    "address": "erd1c7s3p672a7lua32hnr0pzfrwa9g6u3ap8e9v7u3zthdnve76udcquwdmsy",
+    "address": "erd1p58kewf2ynule5x39z8z3k7prmw96505dhj0y83wlrj4sszyvuqsenn262",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9350,7 +9360,7 @@
     }
   },
   {
-    "address": "erd1ky2mhtnyaclyhh3s8jaq9clr9nejyt4gz00pnyxaujq2y4vu4s8s7fells",
+    "address": "erd1hz0r9ygwyt55s00kwawdkukf6kcgq98sujlu0409cxztxpvz7gms99zx2j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9360,7 +9370,7 @@
     }
   },
   {
-    "address": "erd13rd8m6hkemxcrn20ztax47s6uzp6fhl65vxk5x9nh2clc63kpq4sheeavv",
+    "address": "erd1w0nvju5ue28wsnvkyqhd2v3ayu5ly8xdj8a856jzmcx49ztnjtgsrr8v4j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9370,7 +9380,7 @@
     }
   },
   {
-    "address": "erd1wx6r2zpcmg9fpxdp6e5pssmy5sy6k2kfr7yhfkc8qgdxfcx83k7snyagaj",
+    "address": "erd1n97ul00hqftx00l3et0mwtumw83rjz2yuw9zh37k7pw58zlx7qlsznfsf9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9380,7 +9390,7 @@
     }
   },
   {
-    "address": "erd14ma5zclhm066d20y4tgru35ypz7n69ssg9m09vgq4u6r78aq4hhq30nly0",
+    "address": "erd1aeqdvtsd2xkwjfjlucw4e7haspd6km0dfdd8vrqge7vv428qw7hqmdc982",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9390,7 +9400,7 @@
     }
   },
   {
-    "address": "erd1ln2x5hl9m8uy8d0rf7l543prx2nhmm8h6jrsk2qp3a3mq76hmthstrjv4r",
+    "address": "erd1hcjukxc7ck0rhvrj8r6jl0qeaw3dahldzr6f2zn7q2jem4fsgs3q0c5qxt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9400,7 +9410,7 @@
     }
   },
   {
-    "address": "erd1te0mu6gpxlg2pcj449npvhke3xy3x56k8rdqaqraanq7qgjt6t9sevyla9",
+    "address": "erd1jganrg0x7znaaptp0g87udfqf247af3t3xgetn9wdcah9lvh9r7qnf7m72",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9410,7 +9420,7 @@
     }
   },
   {
-    "address": "erd187qvadqe9aa94ygs4w9y7ke9t239myhapvu3m6jqvta0yxz3zlhsgc62py",
+    "address": "erd1g5dnl3rkedhyfz7klv5j477uwk6kk0avrlay40u229ac75y63nvq5cny5f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9420,7 +9430,7 @@
     }
   },
   {
-    "address": "erd1yrly7hgle5wklp32myllrqwjhms7yayw5f758wdxk5r9zfv2w94sufgj8z",
+    "address": "erd1mzw5m0tu8v9st5yq6zca339snznl7vwznqtxuamakjl9vpfcvegq9j0jdr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9430,7 +9440,7 @@
     }
   },
   {
-    "address": "erd16kl8ts69wnc0c9znvyc680egrd27m3qcj3upnd5hkukqg8hru62qxf9gty",
+    "address": "erd1xaej9teha9sn840dx9jmgjyh97h2v30aan5484ur02ntwmf9xncs96pexn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9440,7 +9450,7 @@
     }
   },
   {
-    "address": "erd15g0p8w33u688nk284xtr6gmgw4ermvw6q28j48xurcupskkq5l7qxvfhwy",
+    "address": "erd15ylgwjcux7v55vtz5xre28k536kt60pqa42d7fyhztxex32d3ngsr850q0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9450,7 +9460,7 @@
     }
   },
   {
-    "address": "erd1jzsvn4sujd9stfy5c8ekmc44ts4aqncjf6p6we3ucs82mx3hganqf438xk",
+    "address": "erd1fr8qlgqte2d2lx3eescgxpdq6fdkp6paf00n83lljuzuw7fm9ecsj8jkck",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9460,7 +9470,7 @@
     }
   },
   {
-    "address": "erd10aueypurzmt9dkdw7jdtr8u8na9nu0agwy45ngffzt9fz3rjv2cs8vu5gt",
+    "address": "erd17mdqjpw4m890rxzqdus0s4s48t6377srg4kdzr256328xehs8tnsler867",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9470,7 +9480,7 @@
     }
   },
   {
-    "address": "erd13pgpek0zpg4wkj857wgrl06xqffjrjpxrj8j86td7uujg92lewtsxy09ne",
+    "address": "erd1yu34hzlpyrutwpcgpz85ewwh9u2nlj7rt8x4h6kmaxt3yrcdajsqe6szfz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9480,7 +9490,7 @@
     }
   },
   {
-    "address": "erd12cvna7puwwgrw0zrhw2ycqnzpceavn7cecjplgnvpejcqam8javsspdyyu",
+    "address": "erd18mppq02qt76nk40ynqqvxytqne3jtvguzu74657m5l3r3eqgq2nqaae8cm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9490,7 +9500,7 @@
     }
   },
   {
-    "address": "erd1aa9x3x9m4fx2m57395alqazlj40tcseardxzxfgvvhmqvwpmq5mqvumh0y",
+    "address": "erd153evzl33skmfwr9r06nc6z7qep75lhm75tt4v8ptlwahf4upaf6qsxt3rq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9500,7 +9510,7 @@
     }
   },
   {
-    "address": "erd1x48uamyc8h6g9xccx2wl7yq096l7jmnycn7jpp964rreja2nkvtsutwwnu",
+    "address": "erd1zwlkerwmhgle7ay2c69hvk03s222w54mdav8y0l4hcsgp74n92qqmrzp45",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9510,7 +9520,7 @@
     }
   },
   {
-    "address": "erd19plg5vntnyx4y5kjc587uweymq3u5ldvtseg5zf33xkwqa6hwucsnn323a",
+    "address": "erd1d3477nqgrwvn56639cncy9d3a00pu2aljxrphea2hg6qk7y49z9qrje88m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9520,7 +9530,7 @@
     }
   },
   {
-    "address": "erd19dd0tdy85ym6emm4ug455y5vc23tquvpgrnnchajvhyxhvveu4esgx2jjt",
+    "address": "erd1xpwxjng22xja9zrkdqhrgqzpnwpnrv22xyfxr4kjl22g6tlnwkascv23h9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9530,7 +9540,7 @@
     }
   },
   {
-    "address": "erd17cc8ggey49h8j29zlw9d6ls54drhgp2fkvs96rx2f5lmnmuxqsjqcrxpg6",
+    "address": "erd17h900d50zkhkzxmga324gztqcuumm7q6e7xg8s7xslmz9r9j4ctq9x0ccn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9540,7 +9550,7 @@
     }
   },
   {
-    "address": "erd1qed7vpt7u9l465hdqk9gdqnfl7qnu9tydgzarcr2j723endjelvqr598q6",
+    "address": "erd1gtw4ev9fyg9v0lps3shn3vn4x5fn8a3lsgznrnxn5lkddzmgfn5s9d78um",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9550,7 +9560,7 @@
     }
   },
   {
-    "address": "erd15w3x53rqmhfju9xpfa2v94uje3grvxz6k9k2jqjwml6cdykj0sjqky0zt2",
+    "address": "erd1fycnxz928ugft8jds5nryet36zk4pz65gp4rras2nsca4s6t478sjm0py2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9560,7 +9570,7 @@
     }
   },
   {
-    "address": "erd1z0g0qf6qay3vp0jrj2lx8mzxmqkkjzy0vl6cc8fem78s84wvjj4q3k5xnm",
+    "address": "erd14q35h53xasnq88zssf9c5jvrpc4d9jqs92h05ltqklslg89mjqvsrp8k80",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9570,7 +9580,7 @@
     }
   },
   {
-    "address": "erd1hzn29v8d9glg2ktj9kdg58q3ag65ys2yphkafekyde40v9mpxccsfnlfsa",
+    "address": "erd1v0q4s0mjdk9y79ydwpc7eyn7yhrvcw2usjmctlfdtvpcxfwp89jsvrdnr6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9580,7 +9590,7 @@
     }
   },
   {
-    "address": "erd14zn8ns3jr3t9f7n6phaxzcg6kflz0x42dzqnvhmduhtycdjsdwlsslqg0x",
+    "address": "erd1ea99s6akh642ydffcg33e0j4cfgg25sxwv9rd5dvwm9w3qm0v6uqveluwy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9590,7 +9600,7 @@
     }
   },
   {
-    "address": "erd1f4r6p67mj22n30gcyvcgtj3l56j4mhtvwzj93kmdfu6v8ed4wedq03kgyx",
+    "address": "erd1tz5h3alanduy49277lnj7adaekztlnnhy753pzpv34kd4kqul4hqeum4gz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9600,7 +9610,7 @@
     }
   },
   {
-    "address": "erd1nr9w0gny35kgfn6ll05wysgfy634kmwrewp9gwuywc6224kldklqwcegtf",
+    "address": "erd1k0emsdaj3h2vd5dw9tclr0ufl3lytz2zpkgf2tjy5mg2m4n6ynkssuz6s2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9610,7 +9620,7 @@
     }
   },
   {
-    "address": "erd1akwnwwwetd8mjkh6rexqtcug5dq5peyw2938wk27kxrr9rhwtdaq4zxdw7",
+    "address": "erd1rhq6andd9zwa32fzahcxhpykxefjj73qxgxxxn4ap684rp0e2vkszrthja",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9620,7 +9630,7 @@
     }
   },
   {
-    "address": "erd1glkhws2tc8s8l69nvd5pzlpaynm9uvskrev6dvzz6vh3anjn0p5qw63pl3",
+    "address": "erd1w7h78xcfvrdpr9xxwvq44gyhr4f3s0shmdcfrxas0zfxhwygn50q5f25sv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9630,7 +9640,7 @@
     }
   },
   {
-    "address": "erd1xr7pqdcrea2rtdxqrnhay6gjsw20a4u8x99cfjv8s9eqaqh96sfs5jjnpa",
+    "address": "erd1yw5k7uv65a4kvp9ag53ug96qq7vm24z9tu32jvl89mydmmzphkwqp3d52g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9640,7 +9650,7 @@
     }
   },
   {
-    "address": "erd1xaxqg3g4xzfrtyp4dcw76zev489f7y0dl3kr7vv3facwr86rz2vsvynlh0",
+    "address": "erd1x8ayzxu9vuwn8j9t46xxl7llm7z49n2d58zgl074mxrfvj9c94pqgdhy05",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9650,7 +9660,7 @@
     }
   },
   {
-    "address": "erd1j4kkm5yz42sxc6cdcnrdgqqcszvwfv8gx4s2zl20m6kvxl69ttcqk3vphp",
+    "address": "erd1qvqc9ssg3hluvpl2h88uya4qfmlf4hjd9zqr73mvy60mej7fvh7qgzxkej",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9660,7 +9670,7 @@
     }
   },
   {
-    "address": "erd15th7cnzjc60ur3szl6uzdlw7hk0tx8zq3dunjymcqyh44dtedersnlyk7m",
+    "address": "erd19njnrv0clmatgew7g3m8uvrhhl8yrqwu5jnm92fprckhgjwua2vshtnmf7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9670,7 +9680,7 @@
     }
   },
   {
-    "address": "erd19dprc88knsrh20mg68t43rz32ug08twcl6df2g9wam6x68aat66qqzjkam",
+    "address": "erd1ulxx5lq7vqa3x5x6mmaegueueyrnxnuu20ax0f33uwyg3pk243ds96nc8l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9680,7 +9690,7 @@
     }
   },
   {
-    "address": "erd1cthzlqm29gpnfclx24cp6uyqsv75aqf4lc2sjz2gvnz4pxmqf8psshs4nu",
+    "address": "erd1mgkuz4q96gxfrlr7nvzc2hekr77kmff5a7aq9g9txpqqmjx4e2fsuzfylg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9690,7 +9700,7 @@
     }
   },
   {
-    "address": "erd1ctgv9v8ze6uhtf9rns6ruf2pyhepmna5gnxd2m4n6yupppqpdylsrmwsje",
+    "address": "erd1ze6nvaph0ka88stph8kyh4ksuvttr80fxkfj0d807kdeksrkujwsfw57z3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9700,7 +9710,7 @@
     }
   },
   {
-    "address": "erd1l62kh8f0ddklw9a76srth7x85558gsdrq08xv2ha9e4drkkh42kse52cpt",
+    "address": "erd1phdjxg3u7ruyx37wx5986rzjjgve5zth6csdaqz2qwnlmeyafuhqu7nvmp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9710,7 +9720,7 @@
     }
   },
   {
-    "address": "erd1rc8tc2rn97vvlvj9pvlhs6qfz66m4l97ltttsu67hzw85k2agnzqquk45g",
+    "address": "erd18yvqmt7p4s9ntdpzt23x3f59lagglsmvs4xadd92wja7fyk4j2cq70tftn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9720,7 +9730,7 @@
     }
   },
   {
-    "address": "erd1xqt74jevrgu47s45shq2ncguwskdp30ch5c06agk0nmfd838sgys00rqs0",
+    "address": "erd1wav5p8v903z92vflqfx97s5m804gnn6lh2feac395gx39tfsmkfqmhuttr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9730,7 +9740,7 @@
     }
   },
   {
-    "address": "erd1hxc3eghu8xs0uz64fg2xuqq2kra4kx4whl4ve5lx0qg0fdlxavnsu4xtsv",
+    "address": "erd1ersyhhkdpvu8ms6qmq5t6043y5v6gt5d2nx43nev2lsxl0fhd8ysp5jrkh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9740,7 +9750,7 @@
     }
   },
   {
-    "address": "erd1y2qgkcvpm8x3e7pnezdxmlr5qnjf8zlzz4yd7jn6w3z75vcr9u0s72c74u",
+    "address": "erd1rwjtgva4zkd6ug3kjl6j5eyuh4nynuuq9aqje9tyz734945aragsd027dr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9750,7 +9760,7 @@
     }
   },
   {
-    "address": "erd1z3qse5589upe7hsk6wc03w9ekcq7d0dxmcd2cq5lth32qn5qw2js86rzfx",
+    "address": "erd1l0cc6smz6jg4lx9gfacweg4z43ldpp32fjx3nng9gu0yvs6wh0fsp5dfvq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9760,7 +9770,7 @@
     }
   },
   {
-    "address": "erd1mthjqffrw9l2jhvkz3qga2k8m7d83vqay9zeafrdj864hz78gdaqxv8l0j",
+    "address": "erd1jvk663hct05f0xnjwfq6xq06q8neul33pq0vg0qcd8yp4dwpxvxq3pd84j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9770,7 +9780,7 @@
     }
   },
   {
-    "address": "erd1ly6e4rdgpwgmvltrwn02kt2puekan7pqwq5hj865gq0d7tsuy9dqect939",
+    "address": "erd1ghmq60vld7t6zh0fp72tay4yruvfa2rnjh5jf32ac2f75ddhqqyq5k6z39",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9780,7 +9790,7 @@
     }
   },
   {
-    "address": "erd1f9pcdk7258jv35y2629jp8r9xma52z258pcekz6ejawnkah9nl6snldp4d",
+    "address": "erd18p5kcu90yjnlw6ht36frju0pcyh6mgxg9g88ffsvcyv0yu0yq3ssmtx65t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9790,7 +9800,7 @@
     }
   },
   {
-    "address": "erd18656wgkfxpqq55xnt8eyjrtr66z7zm4lx9ypkawcr03xjfz3e75su2z6cr",
+    "address": "erd19z9h37eff0ql9m6rmzptdacuh7w9aqrndwq897revdrujg2u5srqujcljz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9800,7 +9810,7 @@
     }
   },
   {
-    "address": "erd1dksmqm7sr0qrwtpfhzwqc78e6tkqwfkd2332js8u6p6fn926l5lq4zqqza",
+    "address": "erd1w9rmez4ynsmj7zz2zgd9s7vkl7qjgl96r92uvqqwl308kz8hpdgsqp03sd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9810,7 +9820,7 @@
     }
   },
   {
-    "address": "erd16jxjvk88gfk2frjlkjqvqlexjjhd02nxqmx5mn45ktleugv6cc5qrausg5",
+    "address": "erd19d5lqksz252w20huldrvyhp047cc0k4pxt0yqq6hkjjqsqpnlz6svl0kvn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9820,7 +9830,7 @@
     }
   },
   {
-    "address": "erd1vru0jllu2cncf32xtqx3h2z4svcdg980k84wlecgnde2pm3cea6qczmw3u",
+    "address": "erd1z3e2tt50zw362207fx4e87tscwsypdellr7thvp4p5sjdvxpvvqstewtwl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9830,7 +9840,7 @@
     }
   },
   {
-    "address": "erd1a57p88tymwslepkqtdjwldzg72a24fc6ae093t6kmhnuwxw2q8dqstx6mn",
+    "address": "erd1tmratm2jtvcqngyzn3uh5hrag40n9tg32t7elu6velwxt62e74aq646d7d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9840,7 +9850,7 @@
     }
   },
   {
-    "address": "erd18qa2fzam9wejlyx3fweunvnmx4m7ks64jmnqsu675hdvsakj3g0sg7txt3",
+    "address": "erd180we494nucard2607z2983g9x805lgt5fc022f47fyullt9r6zls0ffkx4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9850,7 +9860,7 @@
     }
   },
   {
-    "address": "erd1y5lxy5eek58vz9f957u430cdq4sl3tdnrgwx3aqldsnadm8qg9ss9m7cwv",
+    "address": "erd180ngr7s9p566u7ygj09mfulkzq2qgw7wrgudnfxvwpdxwsnn6qtsfcyyw6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9860,7 +9870,7 @@
     }
   },
   {
-    "address": "erd1xk6tf4xj2r87mpj4x8remjn56gm9r2zqu0n7sy2mz95p5sw770as7rrh8t",
+    "address": "erd1wdn7xd0dl658m3qqdm9p8hzqrldhzsnh5wepfh75t8q9mu6kxwpqyzpumn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9870,7 +9880,7 @@
     }
   },
   {
-    "address": "erd1q7ls54w4duekjes2afy96g2ljc4x8t8fx9g5k42fetmajq7as72sxp7m65",
+    "address": "erd1suq7ewry730zeldt4zcx0mgkdmmux07z8e65zjpkvuz03m8waeysqzfd6v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9880,7 +9890,7 @@
     }
   },
   {
-    "address": "erd1ut4m6ysplxw2th3qauj49gzdysxglx4fte7a4y3yxxg702q9dw5qpje272",
+    "address": "erd1de2p086n0t43u0lyx4qwrjgtls22sffza8dkkz3pz956jdrk8lesgz02yc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9890,7 +9900,7 @@
     }
   },
   {
-    "address": "erd17pp35cqzsf0k7wqkp3ed02lta6w53zhq4tpsufxlwemf8ajah3tqzmagus",
+    "address": "erd1ttc0rr6asujux30c72wtn603s3dern3qtse0p7lnj22mtq7jl7tq04f4n8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9900,7 +9910,7 @@
     }
   },
   {
-    "address": "erd1w7mcrwm6hwqq4ucm4edkkg5ukruqw4tpa9muf9k0amfrvl6fx57sfh0alg",
+    "address": "erd16c6wf3pv6p0exzhm5v64kr206zg3cwdawe52evmy4y4wpzf36gsq0smfdg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9910,7 +9920,7 @@
     }
   },
   {
-    "address": "erd1wytaws0zske4fnfkqur5cd8lhk0f8pcw0s4svyk3lupywz3374cqa8nxyv",
+    "address": "erd1cs5tdrqjtx9jy62p56gryx0t97qsuesls3nujmaq4ced6ghptsjqgws3a2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9920,7 +9930,7 @@
     }
   },
   {
-    "address": "erd1y2suf757fmd8e79rkvkgqha7an2dvpuduvcygmwgvmt3a8uf0duqztyld4",
+    "address": "erd1w5w9vp3h7qpu3ceptr43zvk4qe48mvuhqcxq3xl866gcjjqy87csjt4etz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9930,7 +9940,7 @@
     }
   },
   {
-    "address": "erd1pnpdmntm9xl4aa2ksdheh9ujd7dujw4tset3vtfsqaaxlh78znnq8rdehm",
+    "address": "erd17ca9uezp3u73yuq2rgh7xff333dwxmulx9fk7y5wk6vag58k8hxqwk08zq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9940,7 +9950,7 @@
     }
   },
   {
-    "address": "erd19xc7k2htslvuwvkh0e3dslqe4sfyt84p6sf02g7un4ht0v0nyvlqvrzum2",
+    "address": "erd1f0jy38xcllfjujcm282l6620l208uyv2uxzkma8z5k9w5zwk33ash2u9nu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9950,7 +9960,7 @@
     }
   },
   {
-    "address": "erd1gtuhrq2370h3nrxhyf0w23ngtajk6mlmwq0e7hwewck5ye48z55swk02y3",
+    "address": "erd178wr60qx2dfztpannym5temgjr80lpyqeyfffryp06huavmuzr8sv3gngg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9960,7 +9970,7 @@
     }
   },
   {
-    "address": "erd1wx5rvdzdrr73wwqcpfultkch74w57nuqpjauq4jkp3v0wy02gp7s7jwp00",
+    "address": "erd18yvag25tzxhttclt8k2txgvp58sufq72ajfev58elnf0p9dffq7q7hyu6q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9970,7 +9980,7 @@
     }
   },
   {
-    "address": "erd1p5ln2r7f4hxk2m49r4xkk86pd5z5a7s0wkrz53mwe0pjwh97q7rq5st7a0",
+    "address": "erd1uepacv9apug3flu8cam2ydeqzy9jx0c6pqnxd7s0cq69k4r6uyvsnpzzcp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9980,7 +9990,7 @@
     }
   },
   {
-    "address": "erd1fahf96mfnl9p05c0ym4a0tm30g006lghd809jl2azldz3jtm44lsxuem00",
+    "address": "erd15zsl072w26zj32cdee5j98pxa6mrfwvkh9jha0l7xwychh2n99uqgte08a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -9990,7 +10000,7 @@
     }
   },
   {
-    "address": "erd1z259nmaanrcukhsnkecpmsp6dx2e0fpywx6lvwwh47kctky0mcssx470tw",
+    "address": "erd1r589wpsplsxs04t6lx8pppdj76cv3cr03juuq7srgp6dggxvc8sqrfjghv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10000,7 +10010,7 @@
     }
   },
   {
-    "address": "erd1gh6kk70hxncqr38t7p720qd4lxu0p7f8fnta2nqjccxlfkmsgj6qh4tej6",
+    "address": "erd15vxwja0t7um0a73d47qllcprdww7cqzuw4fd80htjf5etpr7s0hqdraahe",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10010,7 +10020,7 @@
     }
   },
   {
-    "address": "erd15jhlzzsz0af48r4e9s3qsfuk228u2tltc3a949d7s0wld9ak2lmszay700",
+    "address": "erd1vusx4w440hjumqtgda22xwtkmcj4nllux9kayz59rga4ut7m89fs7cuget",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10020,7 +10030,7 @@
     }
   },
   {
-    "address": "erd152yf0smtnkpwx7aehsf09xss2juxrtw6g3ytsu5qxksu9288px6q8f8ry3",
+    "address": "erd1j8k80wvfkxdjajpcs0dgcr98hungdzq8wy6gm7zxsxg5ddwgzxpshkqpqk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10030,7 +10040,7 @@
     }
   },
   {
-    "address": "erd1j6c5vk7tmdmp3z23x4keddupcjfr9a6cwvg0a5lyut4d9g5cqw9snsvj0x",
+    "address": "erd1hj0x0shkh2dw6psq5w7gnpxdtqslxwza78t59nq65lltx98jzsusk5eds0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10040,7 +10050,7 @@
     }
   },
   {
-    "address": "erd1p8dqlne0kd2c9xdwe0vm08rdj5ygtp5g0e5a86s6xdcfcs03czkszppumn",
+    "address": "erd1fzpxnvly8u2tq9ky5ztew5mew0kmt70ftcv6jk47cptnc0hg7r0sx54lq7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10050,7 +10060,7 @@
     }
   },
   {
-    "address": "erd1nyrac98m0wf6rszvlhsnjh6tktpldf5snkdk4dppaw0ayp0ddlksck76wz",
+    "address": "erd1e6xvk0suaf5vak3qwj4vgwnr68sd2jkzpp0hckthawmsq6ahlkwqkn6mp4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10060,7 +10070,7 @@
     }
   },
   {
-    "address": "erd1lz0zudkl7fk26rxfhvyrnrmt96jqcccmyqgdhvwcxntacv22zzms6sgl50",
+    "address": "erd1ug9qkhnmk0d63rz8he8j9sk9ry4spa3dumu7w5kvmfkgqfcvyakse4ecp4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10070,7 +10080,7 @@
     }
   },
   {
-    "address": "erd1a8cgqupqdaszed5dq7v4n5xmugvdmsqndxavls8e7vaq6eefdvds8gjegt",
+    "address": "erd16547mvl7g27hy5vphjjc8e6dhlhj9m0gmczlgkwhezvjp5s7xs3qdpyned",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10080,7 +10090,7 @@
     }
   },
   {
-    "address": "erd10hxapkcqpptjsg0suh69723d3e03g76ldmzv0mskjlsgar7nxv8qk38el8",
+    "address": "erd1ty9num2kpyfdyjt20c4wjsdxt0g3jmynwlpp4x509xd7qy869gvsw2nvlw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10090,7 +10100,7 @@
     }
   },
   {
-    "address": "erd1ffsngupldnv47q2qu4xkltc809g4u6j5zpqnmhkrncwqyh4c7yrsnfy2zp",
+    "address": "erd15c6l0alzh430ukt0cccfxt8fpd8mvpapdwkzg3mdp8wxc7fgkdhqhl2x2l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10100,7 +10110,7 @@
     }
   },
   {
-    "address": "erd1uekyq3z29sxtq6wu9xnnnxyza83ya3mdrshyvykk9yw4aglc30xsmll9rq",
+    "address": "erd185cjv6m0cqs8le5675044y0f6q0rqhcuqzq6x936399y36e42u2srpqshs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10110,7 +10120,7 @@
     }
   },
   {
-    "address": "erd1446lu7q9lpnzd3s95u3kdrskp2l3fce29yx35kftr4ewfg4krl9swqgzh2",
+    "address": "erd1c9eqylxwneujlsg3mplur5um75pxylml5ue5q0uksec88l4pvqhs8ee4jv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10120,7 +10130,7 @@
     }
   },
   {
-    "address": "erd1ez5z3wllf7huexfajfz69p4lflfxths7f00y7qx5s4cc4h4zyfcqllrt6q",
+    "address": "erd18lycsa093qfx5t3hpdkf2pg8k3rvreq78w4nwmtuj80ggj6zh23q5f7wtf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10130,7 +10140,7 @@
     }
   },
   {
-    "address": "erd1ecpukytecrlel73jz5xaah970fkyjp6hx7dge3p2k2ezcafw4qespz8q8j",
+    "address": "erd1fcfgy39takl2z2w49ds5376fxnjezghevwwklxjyu8pq8gd96jdqss64tg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10140,7 +10150,7 @@
     }
   },
   {
-    "address": "erd1jyk0elpxvpvxr2x95eymn630ak44l0axyx8v4l2547zytjykrq6qentt2x",
+    "address": "erd1e8sckvszfv0j0dxq9wlhmq55sxdjrufg86c267tlrl83c2tygkms88xesd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10150,7 +10160,7 @@
     }
   },
   {
-    "address": "erd1uc9rdwanslsf09u0za9lzpgntvtgf34fzk0wwnmtmchvqme6jl6q77243u",
+    "address": "erd15wf5sctr5e2ygw7emsw9p9qlqzkalcnpcarx97g55ez0zhmswkms702rl0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10160,7 +10170,7 @@
     }
   },
   {
-    "address": "erd1ede6l8n0epjq892gam269jkz32us5jvh65vdtlwwdpu7z44mjwxs0lslt3",
+    "address": "erd13p4r7lu6gvu4vc4q470grj56r9y4sgs0gazvynuw72h6sp5p3j0s4cnvqs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10170,7 +10180,7 @@
     }
   },
   {
-    "address": "erd15jn6xw3z66a7xttuxcrcaxt9wnkxw4yvk9lh8wzkeycrrqyut5rsjtd3dx",
+    "address": "erd109eec0r6gwe400v2rslac6sun9wp0d7dh3cl5kds4p4lsdspxayq63ahcj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10180,7 +10190,7 @@
     }
   },
   {
-    "address": "erd1umccr8ndakww88vgdcxskk0lsnyyu52pslx3zr490t2gkmjeuckqsysjsv",
+    "address": "erd1gl3m7vn4nkjjve3k0nlgc45rsqdtv8k5yrfmrrlukd92yvl48vyq3nmaut",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10190,7 +10200,7 @@
     }
   },
   {
-    "address": "erd1wvzk2ecqkldcly5xgp6my4v09s96ekjvgmrjddfn7f258yhkke6q32e4xt",
+    "address": "erd1e64pwknwdkua93y98zd4ymcm8clw3qjr0glqx5mu6rppwg3kl3aqskx4qm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10200,7 +10210,7 @@
     }
   },
   {
-    "address": "erd1ap4cfa3t8gp7k9vhjqlxw8tjvsqpw5aafgqwheag9u69yyh7sm0qql3mm5",
+    "address": "erd1uht32aaph6vnlgdvt4aj3aetrhtrem0qdx44zkgevsekhk38rcxqp604ev",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10210,7 +10220,7 @@
     }
   },
   {
-    "address": "erd13g8rgcwnrmpyl7l27xxx6290rvq2azchjaqfpgafwn4sxhzszmjqw85zc3",
+    "address": "erd1huhm85tervdzjfkr6hg6tsh7y64kjjqepnwfkceytdle7arv99msf3hhae",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10220,7 +10230,7 @@
     }
   },
   {
-    "address": "erd18t4kujr54h63sf6rpufqjh5usdt3a4vq29wnp5fhsr43pms87psswt705p",
+    "address": "erd1wd0wgvl0xq92v4wq7zxzk6yjpa56we5fyl2qraqmsl2d52cthq8qj7k338",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10230,7 +10240,7 @@
     }
   },
   {
-    "address": "erd174dwdj6ng7rg0t8hpdppz7vpsg35exhhmnwdgprvq6nus7zvqgysvus6w6",
+    "address": "erd1jre4lkvvglvlyj040ghmhjgyxj0tzwysryl6g4caq0c4v3u6wensv5tn4n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10240,7 +10250,7 @@
     }
   },
   {
-    "address": "erd194w60ttkym3dqpnetd5h7cd705gyxf55zmkgkd7p2gqm9cv3zgjsheg9zq",
+    "address": "erd14gwa7mxh33lnpckwtmr7a7vn9y9ugxnjglu5q6aryufp5jrf53astdgdhd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10250,7 +10260,7 @@
     }
   },
   {
-    "address": "erd1zu5ggffkrj5h8jqnx305ytt4gzxndddc70xw290cxszat78ueuuq86vte8",
+    "address": "erd17jx4c9p5y7mt7ar42agszls8zvns4psunjycnf755hsda6ekunqscmmre6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10260,7 +10270,7 @@
     }
   },
   {
-    "address": "erd1vgpw7u0qr459l3twazacf2u05zcqlyl4fwrfzvkmfslkgjr6t8eqyv2730",
+    "address": "erd10dp55vjf89z9xafegwm9kryc67qags309vr35u44ezsvutl3ususw8w2hu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10270,7 +10280,7 @@
     }
   },
   {
-    "address": "erd13f345sw56gx7exm00xpzyaglvguhlyjd0q2jq6l05lpec4phx6mqzhmuuw",
+    "address": "erd1r7mcq4cgxegnr0zvllgy5wj9cgew4cjmywezr3nf6kms7d6khudsscku6c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10280,7 +10290,7 @@
     }
   },
   {
-    "address": "erd1xcfr0psqk7ut8wmtp6423qtk5sv70lghje9vlte9tqfcgxf7hnmqr3e6ty",
+    "address": "erd1hlgrh57mccf2zqugkg04ec5r5q2azcscnpd79rfpgqmhdl4w2easea32em",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10290,7 +10300,7 @@
     }
   },
   {
-    "address": "erd1xh80pd4hn93ucp5g54pmd8fuxgalet4ks74vsl4x5ddf3nkuw6uqagrt4c",
+    "address": "erd10efd332dy6j6m6tqjwn9q4a55tx7vq4ern3m6k538g22sawh5muqg50h9z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10300,7 +10310,7 @@
     }
   },
   {
-    "address": "erd19mvddq0mrcsd7gnvmep24k0qy5csak6g87yy0pxgfaph2cp8dvcqt0ayx8",
+    "address": "erd1em72vxc5q2thd7k2hahvdndptmz0juk3yyl68kyuxervteppz5vshqqcl6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10310,7 +10320,7 @@
     }
   },
   {
-    "address": "erd1n75wlwlh0ts2zp6kam3ytpk5ek2n75u4k9werwqlqv5mese6adrqha4qpw",
+    "address": "erd1euzeyffgz8qnc8uq6hx0czwf5yrg0j56guczxzu3ypvfx5uy760spkxk5k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10320,7 +10330,7 @@
     }
   },
   {
-    "address": "erd12ucmfgmr9y5evl7nnwmuv7lqjrx5ma0qct4kkptr5rxnyfkyjcusgq67tw",
+    "address": "erd1qqemuvgywkvndwjek7pcm5swpnpwyun6t0wm2u72nafedufk5r3s42dhrd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10330,7 +10340,7 @@
     }
   },
   {
-    "address": "erd1hfdayjfwac63utwwz6kcaz4y93ulzeycxh9m7n7xe705m5xud5qsn07qut",
+    "address": "erd190g44h2p5zxxcdphwes4yft43f3rvy0ssu2w240pgq6usyjwyjyqk32ee6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10340,7 +10350,7 @@
     }
   },
   {
-    "address": "erd1qkq5wgxvfksuus66wh5em26m6ff5wg6hjpu4uzx0gfgfl7lqk90s8vayc7",
+    "address": "erd1ue8znw7ehs5wt5akhmkfjcnfwz5u9fqma7l33uxg70j88kjq0mfspjc5uu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10350,7 +10360,7 @@
     }
   },
   {
-    "address": "erd1whe29sutu6u6c9kggy9qyzhs2l47c34qayh46k7q52fw6nx6yd5qjnn7mw",
+    "address": "erd10d3uu6n2qv6y086s25csv02n09ynxupwhe2jgdesfwa766t46kkqklmk2g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10360,7 +10370,7 @@
     }
   },
   {
-    "address": "erd1fcq3gzurqt9pcmt0yml59xsa07wz2dvelxjkx5xtadae6p66wteqe77w0w",
+    "address": "erd1c9jfhhjkqrqd7pmdj5a8exeq4v3r3kv687legeeup6gy545lvh9st8ykck",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10370,7 +10380,7 @@
     }
   },
   {
-    "address": "erd1cx8hck8nntyuqzln9crkesy4nmgd4pe3s5m8djnkfkplcr2y5essfj75wy",
+    "address": "erd1k0g30m5s249xf94eusa7s8ra9a0s9m07lgh23rsc6pehs34pqljstclv9j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10380,7 +10390,7 @@
     }
   },
   {
-    "address": "erd16r8lm0sltvgeqpdvt34kdrf8lqvsqsk29jq7kgg3kj03czp6yrwsqlc74v",
+    "address": "erd1ht0s03yphg32carjd9eykc7y5fgqprshken57aay4a584apwhxeqq0h79g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10390,7 +10400,7 @@
     }
   },
   {
-    "address": "erd1s0jdqrpmutmc5q74y638hle470l6scp0ht3z35jv389rxmsxnr5qu5lemx",
+    "address": "erd1qw7hc5nmw77lll77kgxtcznets6sxaypx4jcsczv8nw5wksgl5rsjzyzq9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10400,7 +10410,7 @@
     }
   },
   {
-    "address": "erd1m7snqux0hl2ared6rlm47dd5kaqxratnwg3ju446jfym5w3w6duqakjffp",
+    "address": "erd1xjdp8rlyw8h33ywyfvfjqrawkgvvygcr7r7ade5m4vthz53xayfs76vwvu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10410,7 +10420,7 @@
     }
   },
   {
-    "address": "erd1z0glq0jq2m2ghwwtvu3x0ayy5yhsy54a6jmzh30qfppac4m0998qvl86kt",
+    "address": "erd1ewnjh03hk4839t85q32manurv9prn4h3jej2tzymr8vcf4e580cssufpka",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10420,7 +10430,7 @@
     }
   },
   {
-    "address": "erd1mr4p038m8fmfcaz83vjs6du6h7v5avf4hz48wmxshrvzuldewu6sszyr5n",
+    "address": "erd18e4matukqfuldqgyfhesekhy250yv9g0ykyy8z7e889gua9mszps2397ww",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10430,7 +10440,7 @@
     }
   },
   {
-    "address": "erd13474ly9pkh54vnlujc30utvrs7j3xadgz4zztty5h7c2lg0wfq8qpet6qu",
+    "address": "erd1kv5rmv3q495tqdhhs3r987gla5uwg5g43cfh69q7v6hl43t5zzjq2w3ldj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10440,7 +10450,7 @@
     }
   },
   {
-    "address": "erd17fvvqapmhf9clrt3wlunq3n84af236trd2fh094rtxk8tkdglq6q2nh0p0",
+    "address": "erd1t0yym5hek364s46az03ukygxxl62h4vzqqn9l0y7d90k00465cxsj9hxeg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10450,7 +10460,7 @@
     }
   },
   {
-    "address": "erd1uyg02lm97hee2emnrr0nku4a6efju43vszhp6v992mkc8ehwkauq905k5c",
+    "address": "erd1rax3pa4rvdvk58glqf8v05hcqel8pmvd37dg24368rw7c0whz5fsjq4sas",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10460,7 +10470,7 @@
     }
   },
   {
-    "address": "erd1fh53km2xrs998xvjqzul5nw5pehnpvyd2wns86a9agz46ea3347q2aljaf",
+    "address": "erd14vgcpn5eswyx7tmhd4vst87angpmu6g9yx209z940rcqu6rrp4ws8564e8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10470,7 +10480,7 @@
     }
   },
   {
-    "address": "erd13xnvmd7v54dsclkyzdw94f7kz3txzfe6f532q2qdsrcgqy0lcsgqj3fp6e",
+    "address": "erd12k64z7hpdvgdth8hu0rd36maaf9a5543q7mec7t7hu9pf88mw4fsfvulp3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10480,7 +10490,7 @@
     }
   },
   {
-    "address": "erd1q80sxc0ehlezzhaudq9zzljrt2g6ltu406ksuyqe4f46dlunwesq6fxj2f",
+    "address": "erd1n0ju2fc4dacg5glh8favk4d5m4k9tzrn38f3lssjuthgjzgtze3qkd3dq8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10490,7 +10500,7 @@
     }
   },
   {
-    "address": "erd1m0dxhendlsljck6vvkj57jr94leauhmlu4xukmlkxseyj3wzczjq2xu5nh",
+    "address": "erd1e0hpwv3khm7pqztqs7eyg4pwzea92xxqeenmljj95vpss8yamfzqrlmj75",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10500,7 +10510,7 @@
     }
   },
   {
-    "address": "erd18faqfk2mhcuaq76p74fmazjv36930yf5dtmvtdwcstw8fyn04uvsapalkm",
+    "address": "erd12v88w6thd79xzfklqwvp2gxtqwzkjm7sn3wrt66ldj22ykmlj9nq8ntu0u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10510,7 +10520,7 @@
     }
   },
   {
-    "address": "erd1yjw5txjxm5wtrwz84sqjslwwgg0e09le0r6seefgdw4xrglf3vjqqujr49",
+    "address": "erd13drswfxv9a4zw976n66egryspv0gx8kqtuc98pleef3x8qrvhwhs9qf3wx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10520,7 +10530,7 @@
     }
   },
   {
-    "address": "erd1pup5v0d877hsyyk0ah65jm3glfa8qws8g3r0acyedl46ehwpkrvqn0n4wc",
+    "address": "erd1y4hn6jhycydructvrlgmju6jpxrj8ddem5vanwfjal3xq06zcg4q64kxrp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10530,7 +10540,7 @@
     }
   },
   {
-    "address": "erd1dzg28lw3jfpz4xldzd4yn540k9u423mt47wq97f439fzzv682wvsrktkfj",
+    "address": "erd17krcrp2yw04n44r49xanafx2rnuk45tdlwumn06fkgyw3ejnr7mq7c3jht",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10540,7 +10550,7 @@
     }
   },
   {
-    "address": "erd1nfc68cw33hjrjk2ppcz7f360xa904jndadw57xl08e8qw8kwh02sx39nvk",
+    "address": "erd1vl72vu6zmkyah0fdu867yq3wa8k467yul0mlzace3hnuzk40zqxsqaxxje",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10550,7 +10560,7 @@
     }
   },
   {
-    "address": "erd1v4qp70nmydnx3gpw7t9kugux485frnz6lwggga9k42le5ehdgusqypmn5n",
+    "address": "erd1j9cwk2l5g290mjckha8qyzpryf56aw2qp3jwyc8nqspymtu725as0xdn49",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10560,7 +10570,7 @@
     }
   },
   {
-    "address": "erd1s4ydsfmj34z9exj8ksspqwal08p9msfs7y58kq6rl020euknarpqtc5t6l",
+    "address": "erd1aatn44h3ka9ne7e0fv5q6q833wmazn9x4e85rxnc8z7tavrae3dqgrn5cm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10570,7 +10580,7 @@
     }
   },
   {
-    "address": "erd1mjcj306pj7kq9vsejh00rkxyvykxasq2vhwk9uy55h0fj989u7ws06p9hz",
+    "address": "erd1a7dze5z7pxtu32x847a5tfmhpw6rx6sh3znqxtkvhae4gkhtg5cs4tq4uu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10580,7 +10590,7 @@
     }
   },
   {
-    "address": "erd1cuk2kgg4amux6ghurfgs8rasysx2zdw9pj8d9vf92ds5ymh026cqfhnrez",
+    "address": "erd1zv6j72p807amfga9h4ec5r48jhdteejmdgfyh9pvl4umhp0h8d6qj4k8x7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10590,7 +10600,7 @@
     }
   },
   {
-    "address": "erd1jftj8eqvafz8ehsmetusnzw3l2dxw9muhe088zc527a96e9jgr3s7z9w0x",
+    "address": "erd1hju9p3wduk70hvf9quxgvd8mf60ystt0pgqfgadw8qn82l48wydsjezl57",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10600,7 +10610,7 @@
     }
   },
   {
-    "address": "erd14fn389nul3ejgkae3uy3x30hs8k0ntrx8zcw6mcf3dgn55r42tmqf3fmuk",
+    "address": "erd1mtu6me7t08qycvxqtmgexjw4xe8mym6vekhkes6jcwmgkzreukusqwxz75",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10610,7 +10620,7 @@
     }
   },
   {
-    "address": "erd1va0gss5yr2jy0w7zf9v6h96rerq9y95ye52qtmz6tua8c3nc27hs7gwtwv",
+    "address": "erd1053suum8dm76k6jucrww853tmx5gc50rgsu4yfers44a0tgfw26s4mdh06",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10620,7 +10630,7 @@
     }
   },
   {
-    "address": "erd14mp97s0sh5md2cujw2zrc9fflm2la06sh5haystqp53pa0zg90us7qaha8",
+    "address": "erd17029rzl3enx3pzge63rdjnke2t4j8lkk2hn6sp7vsckm3s9e2d6q4el206",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10630,7 +10640,7 @@
     }
   },
   {
-    "address": "erd1nfpzppd5tjpttm3x5st0nkpy0y3a8lte5l00j82efzu6tfnypdks2dmxj5",
+    "address": "erd1pdhcxzkfnj6mye83khrqkytv8jlzwzp532lgzljhwvfa7tpursvqewxegs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10640,7 +10650,7 @@
     }
   },
   {
-    "address": "erd1w05ag0dlmpsfhwel6nluxm8hhhayrxuuza9df5mpq33ds3pnt39qtn8zrl",
+    "address": "erd12hwtsfrxgnqf0y8ahw79rfc6gtt0kc2250gpyezgc0x9j4lrf25qvjhy35",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10650,7 +10660,7 @@
     }
   },
   {
-    "address": "erd1elca0xdfk2ta8lg0y9cc8srygn8lkuplzpgm6mfefds4lvc9y7xs03me2u",
+    "address": "erd1j2hgsv6ke9kmx8z90vu2qll74tqwk4pm2lysf527jja0tzrhwf5sfgcyej",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10660,7 +10670,7 @@
     }
   },
   {
-    "address": "erd1uz5t4k2ywnrwg40mja379vzynszz8u49aj8sx0qjd69tfz6l8r7saxs7gt",
+    "address": "erd12tf680nfc82vy7q0749p8h4gfpnsyugca2pk56vwm2g2csnp3dwspm0sqk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10670,7 +10680,7 @@
     }
   },
   {
-    "address": "erd176y9dlscqmvuplxntheefu373cpnxvsmvmwy7zjfcmj8cmedp6csvcu2n6",
+    "address": "erd1tswelwctzuazf6lszf75cqk4p4lmap3ektk7qrmya4qajxtrek6qjk0dpw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10680,7 +10690,7 @@
     }
   },
   {
-    "address": "erd1szq8pty8nzzq6gfz3gwa2c5jwyqm92fr8tay9rgq78898q5taa9q2fn4qn",
+    "address": "erd16cnpa8mgmnktkyphe5khf0h0ntl3ln4qa0uagl48cflp9nx78r7qv7xthh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10690,7 +10700,7 @@
     }
   },
   {
-    "address": "erd163vaskhrlzay8tzeu8f466z6yutqwpnjuhusy8unvl65wa6f9d7sfu9300",
+    "address": "erd1m0yjqu4fq6z08khs7lxgf95qs6j5rm9066v5d56yygvdja83tp2q7nhru3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10700,7 +10710,7 @@
     }
   },
   {
-    "address": "erd16x77uz5s5xnljnhul0cpr7czdg08znnrx6r9lk5sztzhvkej5epqft6s2k",
+    "address": "erd12h0dlqe770gp90t8unjlnjzx4f29a0k20uzlzhuxatnah45pugsqjkeflu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10710,7 +10720,7 @@
     }
   },
   {
-    "address": "erd100r5294n3k2lfecef6489xj4f9vc8upk7rz2c6gusvjmmdz467xqstu94h",
+    "address": "erd1579ndqp9lzsee9lcj3gar8dazn5xw2wk8z5wg7lk7ycwy9u54mqsecevdr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10720,7 +10730,7 @@
     }
   },
   {
-    "address": "erd10mlrm4gqg6d4kpdrulef3g2pj4mzgxs73qyrv675427p76q573rqr3zmrs",
+    "address": "erd1jy3lve4lhqxy5fkw7xr57yec7hy0k5ggy24j7e24nc4fnw536swscg0uv9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10730,7 +10740,7 @@
     }
   },
   {
-    "address": "erd1spykuhxj5v7206dq9jfauxylrldx4jwmmn495mrexjfxugmkkrnsfnusfd",
+    "address": "erd1w4u42tyh0v6uzkwt24e7rvsfrzpn5zjsa7x3cp893d73rydj7jmqug5lc2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10740,7 +10750,7 @@
     }
   },
   {
-    "address": "erd1fxw5wwekeh78mcwq7zqsvzng4nkeqey0tglawc7wd4q69zqegwssf94733",
+    "address": "erd1864rl3lrft0qzxgh9uhrt50rahka4jk6hkk9wrds39p2q5uzn5sq4hx048",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10750,7 +10760,7 @@
     }
   },
   {
-    "address": "erd1gdwvlmgqc0d69n8t8r03tgudrfrmk3v6x4cphqjfw5c8y8zmxj5qz0eq8n",
+    "address": "erd1s3ydk7dzt4z4u97pcp49rup2vjd4j0r9el3ptzmcgm88fyk8jslstpy4ja",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10760,7 +10770,7 @@
     }
   },
   {
-    "address": "erd13keg0jlfjmhjldlkkchpqpdttnzjrn72nv4lcr8cgs762ucvg5csdv5tv6",
+    "address": "erd1hft8wjq6pzg839yfxuue3mm079rlyyrxymvfe66mvtvnpdygxncseekeah",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10770,7 +10780,7 @@
     }
   },
   {
-    "address": "erd126u64q6ljylgrwr4v0jg9hmvqspelt95fedh4ehknwudx8akl7jqd4266v",
+    "address": "erd16ywqx2csyrg92c6zymrffxjdvgl0g63zf6zmpggsjfdq5dta2v6stqnarn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10780,7 +10790,7 @@
     }
   },
   {
-    "address": "erd12wtu0ppjlrzwx3ahh0q90926wzpj6hzxn6uhgjg40d5rndttyl7q20lu3y",
+    "address": "erd10lete8u66wg9e4g4tcft5sh4ums68uce6rseqj8uavc7m9lvkutqs689gj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10790,7 +10800,7 @@
     }
   },
   {
-    "address": "erd1ud4hg2eaae7hk59qkyrddxkmcxfu7pucvcwjw3ygqn2rxjm7cujskm9rjc",
+    "address": "erd13ndfau8dyge3sn7tdxp4a5cetjla6kpkgl0zntcyx8wxf273d4qs6dem7s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10800,7 +10810,7 @@
     }
   },
   {
-    "address": "erd1f0knc98y9uf4yfh8pc6ac7eukwwy386m9h3tl0v43g494na0t3uspsx7hw",
+    "address": "erd1d6tzmvylaa7mzu2v6jtntfhf6x4zqg9rjneunwsdgl8mf7kpk6kqyr40ua",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10810,7 +10820,7 @@
     }
   },
   {
-    "address": "erd1gg0z2yah4zjppfgd8qk6c763a5ll9rvja5mvz07495jn7j8qvfrs3sfhev",
+    "address": "erd1zugn8m7phk0n3epepmrwhgl8nt96whwslq9r44e63r0vces42s2q7qw4xv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10820,7 +10830,7 @@
     }
   },
   {
-    "address": "erd13jsl6kavhvnpd97drwfaqd7lzs3wda3ftgkcl5svgyasnafrtm9saz4aae",
+    "address": "erd1s9ppjaf0ezn3czmv9pzht2lkvs4pa0t07cghjlpeyzxq9dxzk3vsahjlka",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10830,7 +10840,7 @@
     }
   },
   {
-    "address": "erd1cndpdqke886wvpzq4qyzsqa8mdkq6emwejpelxr55gmuffqy09gsnv7qas",
+    "address": "erd1wk6wkqv0lzzkjfwfgrzrrdj34m75fshfqhlfh4465z8vu0cgq76qg7yql3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10840,7 +10850,7 @@
     }
   },
   {
-    "address": "erd14fjnmfr2glwhzley9jhmks69xwlcgrrhhregag02nktmaw9nj23q9ue7m7",
+    "address": "erd1xqvqv9qcfs97xhzuuahzw5llvkdmqmc5rlf52ffvl934qpxgf98qulptr3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10850,7 +10860,7 @@
     }
   },
   {
-    "address": "erd1ksh9us97um72hm9mpv83wl67dzz0q6qlzgdul2g0w36rhfs7lqesk3ufyd",
+    "address": "erd1lfgtddkwymmf3qcht2hry86zqlw5r4kcpeqwlw6htvx53f33t4zsj7tt5g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10860,7 +10870,7 @@
     }
   },
   {
-    "address": "erd1l5ehvx6vvfuhpzyw076puy3vykdaxdk4l46x63vxlmanyh6dt8cqf5wmky",
+    "address": "erd103af6kz6yywhj5r7rlx56k8zqsu59pcmckkmrtud5xg9jjzw6j3s6q3s6e",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10870,7 +10880,7 @@
     }
   },
   {
-    "address": "erd18s5gg5nagxm67ls07tdsqehjrr45vmerxfdwputqs7z5t67gdghsy0k7qn",
+    "address": "erd1jmurp82gkqwufeddhgwrqghnjjatd5l0l7vu59cusd6mfdgykxssvqukf8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10880,7 +10890,7 @@
     }
   },
   {
-    "address": "erd1asdkx7x3rpkwvazwzulenuhex0uxe4wgh7n0jg02eul987eaxrlsv9h2le",
+    "address": "erd1at9llm67f5kws5xec7ukemcqu4ndxxf0w0lcrspsh6jqnaa5g43sydax7a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10890,7 +10900,7 @@
     }
   },
   {
-    "address": "erd1fh66zw0tv2tk57hgcdqmurtsq6v55r0rwa6kg8jrk833r09nuv9s37q2qr",
+    "address": "erd1vj8pv2juyt3vpd027q0jsms66ccjckkjdnmx8l5yapl4r4gta0asr4xuld",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10900,7 +10910,7 @@
     }
   },
   {
-    "address": "erd1avf7wglcjh4s9zn4czdv5akd8rcpla8j9sa9su6fmzksut0p8x0sewg9t9",
+    "address": "erd1x9mwuwrjd3vddg8q8mnpgqt69mx7xc4wl3k8pndvjydekgp4e7ksdecd2f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10910,7 +10920,7 @@
     }
   },
   {
-    "address": "erd1zwgu2c9ymjcll7r26gllpekckh2svs742rwafcye52ydnxt7ta6s7csmas",
+    "address": "erd1vtawmklz4pd6qpjlmzh9pfn95rs3y6ke5xml747ept08us8m3eysw0mv3p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10920,7 +10930,7 @@
     }
   },
   {
-    "address": "erd1hg9l926ge2d6gj4syhh26326tgykcty3x5vpltf3t7e4mvrqav4s8wl5tu",
+    "address": "erd1qynntdzk2dl2wd8msxklr86xpw9nhkwelpx2zs7u56q2lgpmq55q484paz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10930,7 +10940,7 @@
     }
   },
   {
-    "address": "erd1k4s77trcnkdkn2ygs5usrngurswpul77pa9puc4ljqwckcn5vwkq2hm29z",
+    "address": "erd153hwqr0cf5mvkmhm9n3zr9wf2vg9xdpxwew9d0q7xtl470j620lq7nd280",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10940,7 +10950,7 @@
     }
   },
   {
-    "address": "erd1ej3nylmg66h43p99scf4lj4yyw66l4nqttt424g7u6y4xcgf8y2qrszqxs",
+    "address": "erd1gf9v7l0uds7j3shlrsrln0tp249nl997sdkh4l7a6kvqd79ct0lq7pzyfl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10950,7 +10960,7 @@
     }
   },
   {
-    "address": "erd14987hduecxqlw9wu4mm7ese3y5s2n0z3jjz68msw87rys3stk8vq8fp036",
+    "address": "erd15t34y7jjas53lh6kmugpmfq7tynucz99tlzq4cjcxvn77epwvkmsa8yw87",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10960,7 +10970,7 @@
     }
   },
   {
-    "address": "erd1npnqnzvtgjjep5he7q25lh037qqtl0w3ttqatsuunawzgjgh4evq3vuz22",
+    "address": "erd1uae5vasrfuysaln98vt5rzd5a0szyrntud0tkpzcmyfcuda2mm6s86dzhx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10970,7 +10980,7 @@
     }
   },
   {
-    "address": "erd1rvch8j9qwt0lauc9vk35s05hh77lg6yvr9etge3pk93r2dl4w8rsdryrds",
+    "address": "erd1t8e6ulfzyr44tmp09cd4mez66d458hh223ka44t85f5fa0eeca4sur4v4y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10980,7 +10990,7 @@
     }
   },
   {
-    "address": "erd1r66xnd2k6mw3sjrk67mgv5c72dvvpzs49247vq3jyk2nywx2gamsmtvfq8",
+    "address": "erd183hz9yugdzzrr48kudqtf727ra3yn5d8qgpjvsj7pxmj5f7shfeswjk9wc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -10990,7 +11000,7 @@
     }
   },
   {
-    "address": "erd1cny5fz6y4qkzfd3xssyzlu9wcv4any5x34js3edq2hzgcpq6kdrqvkhc82",
+    "address": "erd1r9nkwwn766g45fhvzjqdh3nl3ywykpfra0faj3597evlntu6r45q02hef0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11000,7 +11010,7 @@
     }
   },
   {
-    "address": "erd1ham46qgs47f8a9f738a5pt754dv5p907a5t0s72jm2utgs03ykns85wm2x",
+    "address": "erd1558mg9u2vwglh7adqgydzff36zwlk4w075lyqvzrzsgpvvkn9fzskhn52f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11010,7 +11020,7 @@
     }
   },
   {
-    "address": "erd1snjl5a5vze4eeca6fjf6m0ksu09yay4dx7nzh2japnhqa4aytk8q9p84h8",
+    "address": "erd1le9677vgz9jwt94j7prgscxmgz77l8us2xu8utl37wc3g6cw4maqa0rk26",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11020,7 +11030,7 @@
     }
   },
   {
-    "address": "erd1lmuxuyed7csfuv8qtsnnzr95cyk24egxmay3fxn9mzky8xduzlnqxpqy63",
+    "address": "erd1tedw3rg0zp97fy7zrcqwjgml97k0lyqf28eq2syg0wqrlgmx4avq5jmfzd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11030,7 +11040,7 @@
     }
   },
   {
-    "address": "erd1njv30hpzmwtn0cqpphc35t964ernmv5dv3ac356uqztnmgmdg03s877faz",
+    "address": "erd1mjplg57cdxk5gr4vy7qd2accx4jwckvd62kcsv6a7md4ed96ssps4yy5xm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11040,7 +11050,7 @@
     }
   },
   {
-    "address": "erd1fx89ynx3d0taasjjaae9wcdhe5gmac3upvejzptsaz8c4f086h0se6eygk",
+    "address": "erd1gsp478hhh45tmp62mrqxqc5fnh0r533359up78v2nm6cd2n6p3jsd2ftsm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11050,7 +11060,7 @@
     }
   },
   {
-    "address": "erd1mkjq25rxsykjh67u2gmtut8ekadcqs0yp3n6ekfmtzawxhw9q2wsyvfy5r",
+    "address": "erd172u5laeu68panqscfcra2q4r3azmnlpattntvzcje68x4ecmwjvq0xfmr4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11060,7 +11070,7 @@
     }
   },
   {
-    "address": "erd14lfd7enqpe73hhg2dr90du0dydgp6kf07nks9hjf7ycl0md0hkjqsg03xd",
+    "address": "erd1yu3a9hdepykzuxe4qzzv9f7h89qlnvlh06k775w92rrsx4uyggasjympx4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11070,7 +11080,7 @@
     }
   },
   {
-    "address": "erd14xthke4se3qtxkj0l277t0hz33avrke42j2lvdrlykqagulyct4sz942wc",
+    "address": "erd1x346z7n2ew840gyffe93djgvjzmgq4yxe9t6dmydel679zdy2k6sa9uf0d",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11080,7 +11090,7 @@
     }
   },
   {
-    "address": "erd1xrh0magcsmeljgnue8leg7uyldynv04t4ecapk05wnf8kncrkz3sxcjhts",
+    "address": "erd15jzx6l2zeem9k2p2t3w45kypd2zsvecwxrqz8k9rgeq8mr23e8wq3uc9ep",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11090,7 +11100,7 @@
     }
   },
   {
-    "address": "erd1setyt68vxxe62nvrx2txjxzcjf59jsfd9q56zxww5z2qhfxgyfeqwpys2n",
+    "address": "erd1vc96sq8rev0dpfrgfn3zxvefh8ryugcmh70a6l2rtwrmgxgjldwq9lnruk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11100,7 +11110,7 @@
     }
   },
   {
-    "address": "erd1d96yyp2wukgg30sq2qjqet6fwnq7s330hggzvdvptxrklqny63lqt3vhjq",
+    "address": "erd1uu03g33j62rg3knd35mmedmnhpzk5j8t56guvegsct2p8feeatsq9h5a7s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11110,7 +11120,7 @@
     }
   },
   {
-    "address": "erd1cmt05p96ugyhs9vlupxf4szxhfhj4dq2rgn40zwfxz0fwpgf9fgs4s8mwu",
+    "address": "erd18dujj49js8x56uymhpfahg8y4r0z4mfjv580tcx5udzh62sr4uvsg7u2f3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11120,7 +11130,7 @@
     }
   },
   {
-    "address": "erd14qna0pldddgpwwp7d20ysqkd726gleq37wez4j2fynm4kypqf6wqmva0zj",
+    "address": "erd19t32yew90pyv4feu8u95j0ukhmljd49nulft688ac87ddsspwd9qfzkhs2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11130,7 +11140,7 @@
     }
   },
   {
-    "address": "erd1a5mewd7xsa5ad4wlkax2pyjjj9jyacqyalwlzag3wm83lllmjm5skfhzmn",
+    "address": "erd1rxz74wd7m4x3n03mu5cvltxpcptszmpy4kjn49rc0f7gf26345dspd5xf0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11140,7 +11150,7 @@
     }
   },
   {
-    "address": "erd1hxa8zyj294jw422e4zpvzu39pn930s67uxvgfw3ruq3vh72ud3tswxldm0",
+    "address": "erd1zdj5hd7apcnyawvqsne8juq7jaxgdsqe9wa7dmytma5hgxkvrvrsydcruk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11150,7 +11160,7 @@
     }
   },
   {
-    "address": "erd1smany4arceahzf3p9p8usd4l95mmgarz2pcnn0yvervtygjrp2tq6sexlx",
+    "address": "erd1vl9w3wldlz4v27uhkggh44yqgngdgk9gvrguhqldkh42j57vdygs5gucch",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11160,7 +11170,7 @@
     }
   },
   {
-    "address": "erd12cne49x5fnt4pjnnwcvk78lafwju0wrra4h6nmcgq0qpwrwwy6gswp8jmt",
+    "address": "erd1rlndl4q68atykylvjjyhvtwmd94kjx59f4jx9k5lzev4ceta4xcqm5ssq6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11170,7 +11180,7 @@
     }
   },
   {
-    "address": "erd1lnpswae5szm6xajdr9qutakpw0ykxx6pkunypmtrvrqds9jlnc6q5ukfkh",
+    "address": "erd1rz65yuxv7vrh334hvdgr05vkwxug6rcququs8jf53u23gflhch8s782qfd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11180,7 +11190,7 @@
     }
   },
   {
-    "address": "erd1z5u73q6x24hgh2n2j0q6f2jpxvyfmvxnsj434dzwn6dpsjnxg8usk4qsxd",
+    "address": "erd1z5p4me6h5gpd2e2vfd8nxwlw8f0sc9659wsls0dq5vyvgtftaxxq4gc6ey",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11190,7 +11200,7 @@
     }
   },
   {
-    "address": "erd1x664u9lsltjl7nwn98khc6zpt96z4acsmkrpcepsa6aw8c9ja6ysfkjftz",
+    "address": "erd127fyg7uafqk0wakh56g9k8as88p44wh7wpt42ruerveq4uxs5f7qv67spp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11200,7 +11210,7 @@
     }
   },
   {
-    "address": "erd10k3zaxllzatwq6nd05r4nvug2rrlu03uq3efev8c47p5v83plv8qvzywdc",
+    "address": "erd1uz5djkm84llckajzh22x8tpecqtxlcglvwq9gwryktkmrnufg8wqgctn9j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11210,7 +11220,7 @@
     }
   },
   {
-    "address": "erd1eg6q2syu5g5dp2qmvs8f6uuextwzuhp3wv0uysl3esf7adtud8xqc33xa5",
+    "address": "erd18fengn88ds4x7dqpq4e94n4yw52runfknhv5ph0hlfkanswl38msdlc9q7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11220,7 +11230,7 @@
     }
   },
   {
-    "address": "erd1yn5gn4ywkm0sv5mu0qjcg84wqk48464syjmrf5w2tplz2ns9d7us8wflrn",
+    "address": "erd1k9y38kjpcrpcml9d40af9mpkn46zwz8avyf5m0y3hanqk3an22wql8qxly",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11230,7 +11240,7 @@
     }
   },
   {
-    "address": "erd1r8m7vwylav6rqc6z8mqry6n7prj4650y8apcz5n9c9637r5yuvuqrv4raq",
+    "address": "erd1mg4tt758rvwme8eewf9kqdj2w2qt9ctm69zal3p7y2ut8653lmlsuptsal",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11240,7 +11250,7 @@
     }
   },
   {
-    "address": "erd1cevzce3r2q2e7tql52vgupm6eeyaeuphank2pwzz5rl560v5rpksec83vs",
+    "address": "erd1swdvszqcux9vxxhl386nr90pth6q6d3e3gllh2w32grvnjla4elqt7pcxr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11250,7 +11260,7 @@
     }
   },
   {
-    "address": "erd1tmxkdysmwg6cv7f9kyk5gty2hv3j8pllqhzkyn3xlhxnw4x542sqpn98mj",
+    "address": "erd1fy2vpqaz0x4kpw2zkf733fpaf9ff9lsyk84xx069yahmt9vx2f5s059ytz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11260,7 +11270,7 @@
     }
   },
   {
-    "address": "erd1x7v6tqa6auf6rwev6g05rfnvwctlfsy5g08gmachnq4ttajh8weskdzpm5",
+    "address": "erd1z0t7qftkx2wrqz8skq5mh9ghrfumf8gtu7hegfcwld0weqgsu2ws3j9u6r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11270,7 +11280,7 @@
     }
   },
   {
-    "address": "erd1vn3kqe4zcsxnhl3luc2fv66j3dlzt97rjctrr9z4uydse7crl24qknkll7",
+    "address": "erd1xltlgwtdt0086vjumjmww3amn7yrpm0w8mqqehrf833f8e7jcnsqmtu70t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11280,7 +11290,7 @@
     }
   },
   {
-    "address": "erd1ghxsfmvaph0sjzjuf00e4gk0gv3glycw54zuhe25a2cypmvcmlxqp8207y",
+    "address": "erd1u89tqpq86a6vg5v75lpj9e9g7g6879fkfqth80zxgdxhqtgme98sfjwsuz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11290,7 +11300,7 @@
     }
   },
   {
-    "address": "erd1305s9ledm0p2mdyes85xm73e0t9mt5wg0wte4j27h9hva0r7kf9slfxyyn",
+    "address": "erd1xfdqyz5vckvr8lhwnsuk93fw5nfyw5l3s4ejdzvyc8lthz3mqffspqcry4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11300,7 +11310,7 @@
     }
   },
   {
-    "address": "erd1hvpnp0zg7nsfcw2tmhafak0j50ar5v8ep6jntz6cgv0paxt6gxesec534q",
+    "address": "erd1kpalse4arfn8hfyug5046xwlae03qyyjm6zktjk3pgwug027ak9qpnlwtd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11310,7 +11320,7 @@
     }
   },
   {
-    "address": "erd1nnvl9lmea98fegywp7ay82luxp4m09t5an9cudaceuk52knrzh2ss74deu",
+    "address": "erd1dpy02x5sm3qk0ycp3zsw2td3lvw9a5r6ltn85lfcaq7jegeqx8ksmgfzzu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11320,7 +11330,7 @@
     }
   },
   {
-    "address": "erd1d7tk0myrzdq62358m2d7c40qkya5fjfkuretsfr8syg25eewpk5q6hlv00",
+    "address": "erd1j8se47a6fus7mp87jdm426k4ny052rp9et57a0fuy2kg7xaqpsdsxuxdrc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11330,7 +11340,7 @@
     }
   },
   {
-    "address": "erd1c3gvxlx3eyvhm9w7hzj2wsgcjmhnq0ykqq3d7trjg9m2j2v8kxxq3cw47x",
+    "address": "erd1kn3s3djtqj9yz5z67zv0kwzx0r74cqnp4yu2q625327ae5xsqygqntvw4r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11340,7 +11350,7 @@
     }
   },
   {
-    "address": "erd1u2a20qs9cnfgye0xrj6tmmmfr0w62env5keu4hraah8pt8f8fakquyzshx",
+    "address": "erd1x88z6y7vy0vr27uxgwzsn9zrk3rzt7snmx8dtprzvfgqul33vhqqvman9w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11350,7 +11360,7 @@
     }
   },
   {
-    "address": "erd16ngh78mx7tv3x5dhkchh9gv9vqcxu00s7d6v5dzdl9scv8u090us8y6tj3",
+    "address": "erd1hfs8aj6clhp87mp4zshcjxlx4ql0dcyg7g6xxg7960r0slwyqawsfdmq70",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11360,7 +11370,7 @@
     }
   },
   {
-    "address": "erd1hhjqk479tzn28a904uyn3uzr4pjywg2sy9pvh40jyktzwhm2ucaqhyqsdx",
+    "address": "erd1rjuwqjka5arwswtvedmhm43jl9mhhe9h078erld30jfjx52tz4dsfraf0u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11370,7 +11380,7 @@
     }
   },
   {
-    "address": "erd1trxn936et0rleakxqa7q8zr9ayj34gs2svn9c2dmq0sqdk0pa47smqrde7",
+    "address": "erd1tjt58vq6h2hh3q695yv57c77u49x8v9sa2tyr54dlz6gwmsanawsp5y4ky",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11380,7 +11390,7 @@
     }
   },
   {
-    "address": "erd1qrts5wgsz4qmvrn365r6z729kdayas3l7xsy0778elgzmeu4e0ps03pl0p",
+    "address": "erd1603c7yf2mud2fnkjqq2lku8fd3m0akhdu90zax5v8h27utwsqmmsmkt29l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11390,7 +11400,7 @@
     }
   },
   {
-    "address": "erd1qtek7zywrn0k7wqtlu5nhm0kzm9c7yt8tfx5mxnpwxmxqre0rh3qr5j7v3",
+    "address": "erd1p5klhcxl968v8205yw7d6vsksyhvq26vz30sff5pykla9pykqr2qgk9afh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11400,7 +11410,7 @@
     }
   },
   {
-    "address": "erd1xfztd0che60a4ujdc08ln68f3xgw98zeqzenqxfmvqy8qur7ps4s4d5w25",
+    "address": "erd13pm4s8pahtyc0gwnehvtfl6hvyet775q4pheyr0x7f2m0se709cq5su4gh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11410,7 +11420,7 @@
     }
   },
   {
-    "address": "erd1gkk9hkjhhj4rv8wry9z0pte8qgufzd49u36v9pzs396jk0pwhvjsvugw2a",
+    "address": "erd1elucpg2cdyhspxyslpctux2gjh9zle3g2d2eatw0m2evg0d74nzsnq9gp7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11420,7 +11430,7 @@
     }
   },
   {
-    "address": "erd1qq7d9rsuspg83xa63ez4t2a66vva0af8f3c5my27k4ymuer58a8qgcc2n3",
+    "address": "erd1chm6tk7mc4j6wq8nvegt5v8lew73kzyc8elq6aaz0leektfzem7qk0yj9r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11430,7 +11440,7 @@
     }
   },
   {
-    "address": "erd12w2jpw08vexpdcg0dq60u904kvcr6k9wf9gg7ppjvxt44ks63ryqx2sdg2",
+    "address": "erd15yl4q63zhadj4me73q49tx8pz35g3hxg7hxgckgtay7yct6n0lqq4vnrx4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11440,7 +11450,7 @@
     }
   },
   {
-    "address": "erd1nfu4gaykyv23tu5fyyxfkmv2aftzw9h4wl9vfzj9kspektdqpgtqcf09l2",
+    "address": "erd1gs8xh6sda7ws38jpql7ta8pmkfnj2l7qsf6t6mvfh2s859suf6pqasy83k",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11450,7 +11460,7 @@
     }
   },
   {
-    "address": "erd155y3vzlp4yx5jve9s4m45kvq2calgygdw83sael0e8pjjf5sttes7n3648",
+    "address": "erd1cjps8fmca8629d8g2zdw6dkwr0nu00q30p7fvw2et3vc0js2fczqs8wlgc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11460,7 +11470,7 @@
     }
   },
   {
-    "address": "erd15r5r8vuhn5xz7h6tqua5agzfvx84l35lw89435k966r8hkdwyaaqeu50yt",
+    "address": "erd1z6zmd9fsp27727j8m7ttphf78lylkfvhazgqvl9j27jg95mq8n3smngp25",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11470,7 +11480,7 @@
     }
   },
   {
-    "address": "erd1dyswlug6mwdp90t752ltrt6smkmn2h8fx5s7vs3v8jau8hg0j42s2499uf",
+    "address": "erd1ur7cxc2muzzw4t9nth2n8ugugfc6h6pdnp07lmkam8mq97q7c2qqvuq9x0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11480,7 +11490,7 @@
     }
   },
   {
-    "address": "erd1dcgvaxlkevq2syr87hst0kslf7sq7v2e0mwnfgtzrkhyljjwm4xsggv2ra",
+    "address": "erd1wkxxffrzzfxrx2f2ld5tlfe9kxea8e62mxq3ew8synpd4nw8gdks9dwly3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11490,7 +11500,7 @@
     }
   },
   {
-    "address": "erd19rjxtj23fhx9x2nhau4md88gk3xslyjwev8js02p9k2mq7qd4hrsxjsl69",
+    "address": "erd1x45vnyegy649gvt5tcx0wf5gccnclahx350zwjzymxn5j7af4wcq0x6hde",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11500,7 +11510,7 @@
     }
   },
   {
-    "address": "erd1pla7ny9at0qtnghyvnf4n4sqcst07e09efvp0gvnxj79y5f0xecq2vg5ns",
+    "address": "erd13sayjgf0w95y88c35x0vw75hc7jg8epqct8eryxd4xd5cjpjhl0qc95zkq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11510,7 +11520,7 @@
     }
   },
   {
-    "address": "erd1vnrygdn54r484ey8cp09phsdlwrfwgt0y2zgymxggv93hvfv2rvsgew003",
+    "address": "erd1vqc6h5ckkwlew7wgeyqzqu7j8h5mgs5p0e9uywvkehwzvvh9qwxqd0qyr6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11520,7 +11530,7 @@
     }
   },
   {
-    "address": "erd1uj63duykxmglvkzwnxc4ssgsddlveafp2wuh4cfnf53yx8wk4q9sfq59l2",
+    "address": "erd1wsc8k4r9u84sjun62jdqtl9622l6n6c68t3tt7u5uttqmnqhwyeqfmpqjf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11530,7 +11540,7 @@
     }
   },
   {
-    "address": "erd1r9y6pr7r2ampje7c3kyemyxgh69zxx3vvgx864fs8jhn2muczjxqrkptv4",
+    "address": "erd1j8tjfwfaudwyvefw0naaygkj60uyf56pdvyvxd4yr6s79g9mrdhq8gxewf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11540,7 +11550,7 @@
     }
   },
   {
-    "address": "erd1jdrr8rmzal7za52ajc9v848hs9qp98j45mca8wup2sgkpyqap37s37aecz",
+    "address": "erd1z9zag2wuynd56alpr9nu94kpf6c2akyl3ue2jtrflfppuv24u6mqfy6nts",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11550,7 +11560,7 @@
     }
   },
   {
-    "address": "erd1kjj0dkhtxa3l4j7p8ggdq3zgetpdt7j42u95v29e68dqew0ncr3qfs6nd4",
+    "address": "erd1pazgh60ywdz73tldels02wh2w6ljkmpmfpprxsjefekjueukg5zs5tu4ww",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11560,7 +11570,7 @@
     }
   },
   {
-    "address": "erd1fflqfhx5y7ymqcv9uswgqdp7qcf6rfalapddrg20ufk9ckmlwddqm5z8pr",
+    "address": "erd1gzakygsvpmrwrtavwve3lf3e2qtq7rg2gff647ndrnhxphgdepusd5z4nl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11570,7 +11580,7 @@
     }
   },
   {
-    "address": "erd1qx8jq3llqq8uezamg89pd008k48kkr06kvkj25uajtq7eryjyfrs4cn59z",
+    "address": "erd1rp7ru50y98r379fpeypt9zr2n7su6gyn6rjmgquffec05p2wr74sxvse3g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11580,7 +11590,7 @@
     }
   },
   {
-    "address": "erd1en94sfupvhljjv6nq3w8ha4j3fxj5nmr5djkwu885kqe3quz6geqan7hyr",
+    "address": "erd15k6anssrv0tq0e52c9ey5f8jt9ymwaxvd838uyl6yldhhzkqc3nq9pf4xu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11590,7 +11600,7 @@
     }
   },
   {
-    "address": "erd1l5ukn5g5cnq4a7eg25qny9de6hyycl2gp3hu9xrrl66x0heymgps88qglp",
+    "address": "erd10tsrepewz9jarejctq9cht3mlxqfjfsyvet9wrq93w6qee5gr0wqs069h7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11600,7 +11610,7 @@
     }
   },
   {
-    "address": "erd1ua56ck9udkvnmvg9p24t5hqvzjxl478x7ug2pukwpp7nfgk89rvqx30w72",
+    "address": "erd1xy0hf7t2j56uqfv4f82fzqty0dm0ey83edv52cdavjvl7fl4kd6smce8m8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11610,7 +11620,7 @@
     }
   },
   {
-    "address": "erd13f9tx3wp77uv3wayxl383h35f427hscl2cx7denr0lv6vkc9jajqfd6ayj",
+    "address": "erd1j283va7ds737g008ecctjd6c6k8a8xyv8rmrxw9emhzv8kt8lcwsqeav3j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11620,7 +11630,7 @@
     }
   },
   {
-    "address": "erd1073v32srl4u5ylletl7mt4cprhh3405jsuu9alnkukktpfrnl59s8g382k",
+    "address": "erd18xda8ynw5lzhhchv8qutj29yx4tggt78a22wwwvcljf8pmq0xytqcvy0a6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11630,7 +11640,7 @@
     }
   },
   {
-    "address": "erd1u9mp2h96763mdwavykv0m5y5xh33d5cfjh8ftnvkf2syqxkx5alsmp0h2g",
+    "address": "erd1qtaurd9c4kf805e5dg58gk74ts48e0pp5dq4kfzzutzd2jaqq5cqyssj8s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11640,7 +11650,7 @@
     }
   },
   {
-    "address": "erd1zfzu866ten4mfzs5gckjgg9zq4zhv6nchy904jec7hfme6x348gq3rm7uv",
+    "address": "erd13j5uqxq9wvgxkzhwpq277hpwehetfn2tmuq09er9e9nhq2ek69eqqfvze2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11650,7 +11660,7 @@
     }
   },
   {
-    "address": "erd14jd9g4au2x9tsy0n86fu3nlkqk6w3ags8cvyufq6a0sln67465zq2m7w6s",
+    "address": "erd1s6gaw8ll2sazgd7ww2hqfusfrfrue6qxv7jvqakvw5hqhn4trljsn4kuzm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11660,7 +11670,7 @@
     }
   },
   {
-    "address": "erd1ujge8j3dhee4m5r276629666g4czd5my70mqeafupp44y4hpy2dqe9q9vk",
+    "address": "erd1etyekpfeelc4yq4umdn8txnmjt2nqkfy26kaa0lm5hl44h533zts6nraqn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11670,7 +11680,7 @@
     }
   },
   {
-    "address": "erd1tcmgncx4c22n6rn5a6d0gptrxqyfd0adr6dlh8ksvt8rjgepxuds6qwm8y",
+    "address": "erd1w8hmsm3qpllrqtswjua5c9fdenatzzc94cyqqxa3k4tksh8t9khq8qlnmu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11680,7 +11690,7 @@
     }
   },
   {
-    "address": "erd14e32akglvg43k8l6f2rsw5htpuefejxyy9yppdv9n5y32nl38tascvzjpc",
+    "address": "erd1shfv3mafj3vez0qxjs2fujf3mydjystwxfhumn55p89q2ytfprwqgg2dtm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11690,7 +11700,7 @@
     }
   },
   {
-    "address": "erd1yar8wv3m325mmdkc45cuaj7ntwuh93vf3fdr22n0ml65uzjrnheqdqfewy",
+    "address": "erd1skjz8nnq4p88l749mtmyn52n6hgzvjqgapm6wyh9sstcn7t4r4xsu0ajnk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11700,7 +11710,7 @@
     }
   },
   {
-    "address": "erd1ny6906pm2slggltly46mdaqy0ypwn8yxm8v6ywa2tun7mls7xl7spzrg98",
+    "address": "erd136pe2u5kyp4xzeqjn7aerxjcswkj3vzyp07lwx4kznftvfuhmx5slk4cxp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11710,7 +11720,7 @@
     }
   },
   {
-    "address": "erd14ezcfftysmv7zg6z0wercp9zwl06dr77hkgxsq6j9ky3mc49ndgsldlmkd",
+    "address": "erd1lmcfr92039tj5yny4fhf3jzhepqtfvy7djx53h32kazqx9edt2xs58jwl5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11720,7 +11730,7 @@
     }
   },
   {
-    "address": "erd1h9pmwx537uvldrjpvktedn4nkhnfe50g4f0cl84c5kg5v6mv6mjqtpdyny",
+    "address": "erd1c7gswkxu8z5c365shxne3lm9cveedfktanem5j8zgyxf9qh5wtgsfxfpjm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11730,7 +11740,7 @@
     }
   },
   {
-    "address": "erd158425z5pmtuhh0g00q78q2ejkj2fxztqhucx7ruz572v68krx83q9h0h5s",
+    "address": "erd130p4uk92c9d4w242d0z3luxgknkd9ad235sym06j9zwj4343cx2q082me0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11740,7 +11750,7 @@
     }
   },
   {
-    "address": "erd1rjx7dt4wy6mwv062luwyvxxjtgpuvtgevfd293qu9vf033ushzlqr5k0d9",
+    "address": "erd1shvcqlvnsne6l22e52grtdpq2pt9dzqnv66med7ycsn9g7dumh2sgkyzxp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11750,7 +11760,7 @@
     }
   },
   {
-    "address": "erd1tful3e8strpz7zkazxad2y2lgjactgpk6w3ah0yltager6uqqcksek8unf",
+    "address": "erd1klflm4uwsyv9cummy30er78kckycw0s0vr2wsj6h574dhkyvtgsqyh8kq2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11760,7 +11770,7 @@
     }
   },
   {
-    "address": "erd1nm9zmj6yvynzc87wn3fgmcckcde6ucfdtme3nqhxxlwecxulgp6swssyse",
+    "address": "erd1qwr7c3gp057n3espwhrvwkujn0p9kk9fkudh5w7g2zyfxxlrcg6smkw96y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11770,7 +11780,7 @@
     }
   },
   {
-    "address": "erd1x87yhnrc9m4hp2kmr37gslnguadn82grs4e3kagkz5302mdvqlfst8pg2q",
+    "address": "erd1xqfhfw05jz78sf9rmp4egyys8xuefczw53znd2p87kgyf0cjem0srtgzm2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11780,7 +11790,7 @@
     }
   },
   {
-    "address": "erd1tt74ha50z9y4xle3f80gfxux7azxah0eehyv6j3v5a9n7uqd0u4qe8878h",
+    "address": "erd1r2tgn8rvyemrdwmlm9pgn8rjdhd0wxjf59td5sjh5s645pkkcswsrg8dfd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11790,7 +11800,7 @@
     }
   },
   {
-    "address": "erd1d4lljkz56r2knqswps4s8q04us67cgelz5648m4aqa54t2n6xdlsjlh24m",
+    "address": "erd1eg2jfpfyucpg5dnvxuxfmht59rrnacvmr09u5gjcyjgrp653g2asvxseh8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11800,7 +11810,7 @@
     }
   },
   {
-    "address": "erd1tmmpsdpaqlyth4j0zvskp530p646geudwdjtuazhh27up0j6cxtsksf5p4",
+    "address": "erd1u0wr6hqqy2wc4gd83kh8032p25tssvld4yc0kvksacxh62zq3h6s6avhfa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11810,7 +11820,7 @@
     }
   },
   {
-    "address": "erd1sqkn3x8qjm00tfkh32kkjz4eu3mcytj2lxqqs4sfr3sz5p4dpfpsxdekk3",
+    "address": "erd1tzdf5v25p444ttrc7dugqj3f5895dxzc9dutdy7k6m207n0khrpqp03zq4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11820,7 +11830,7 @@
     }
   },
   {
-    "address": "erd198s3dhgkxufjr9sl8h07lhss56wvpy67g04524m5vu8y49qy92sqr26hv6",
+    "address": "erd1ytxjrze3vadml7n95d2eflf73pa62hpxp0pf7x7grtc9hzefhajqjvdhes",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11830,7 +11840,7 @@
     }
   },
   {
-    "address": "erd1pvwerfqrn7th7w9uhqq664l95dvp5rth3qsjdaejswu2mvhagaqsjxqe9n",
+    "address": "erd1lplaa7fz23w5dgjc63s7wtf9y90w26t008583hz2dmrvtj7hvd7qwyy4lh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11840,7 +11850,7 @@
     }
   },
   {
-    "address": "erd1eg5y8trv80e0x3jlyxdmnj8c2ankzjxyt7kgxs5wqfqcdc8wwrdqh60fd6",
+    "address": "erd1gn3xgcru6jq2vjny9wtt0rrpnsashvns42vfnxlu5nupqcvx54wqw9ev6n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11850,7 +11860,7 @@
     }
   },
   {
-    "address": "erd13rw46w2ar0xr77mz4vq3p9nc6xht99v06r3v075ewnqeugs93xmsw7wdym",
+    "address": "erd19uzv28ejmwzmryxqv853aq7364nccxr2vwlcwg35der0m7w84phql2mlvf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11860,7 +11870,7 @@
     }
   },
   {
-    "address": "erd1j3y80xn9vewuknknvwc2e8trt945ckwru0pzj8jjsgwn53pmkg0se4frqf",
+    "address": "erd1h5fums0uaqmk80r28aa7q3ecpgl26apzdtakye30l4zwn0nu05ts7tgnhz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11870,7 +11880,7 @@
     }
   },
   {
-    "address": "erd13gz8dg4ujglkc5xn062dvn76v4m04ndmves3h78rwyjly73lst9q3uwumv",
+    "address": "erd1k974mwnj43zg9h6chefqd768f7x95saa9sdj963fp0hnh07yfqaq2r49r2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11880,7 +11890,7 @@
     }
   },
   {
-    "address": "erd15j8s9q8dfy974f4nqyj5lanhg0huswyhh64v0063aucn27txj8psr3kwzy",
+    "address": "erd1jfvzsqutwcnhemu46fwswm8lamxm22zekvmc20um9wh6dvzq993qyn3z92",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11890,7 +11900,7 @@
     }
   },
   {
-    "address": "erd1halwee98mnh3lga5x5em7tjsue7kfcetsqmlx34m67pf69vgfxuq7srtxm",
+    "address": "erd1c8ysly08w73x77g2u8zzuc385dyr6q5883avzlh4nweqhdenfftstdt3qa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11900,7 +11910,7 @@
     }
   },
   {
-    "address": "erd18e2nzwl7ta9ysyjf24rm57xetr6m3kf8q6rw6ajzfffg57v5pk6qjvj0j5",
+    "address": "erd1krhhtgqee3fscx4xe7c2wk4hlqaycw5y4xyu24pk3fcfv5h9rvus9a9tmf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11910,7 +11920,7 @@
     }
   },
   {
-    "address": "erd1elpu368kslsvjmeuu9ewew8x3vsnvw9tfeqvrtykkxxq2tdlzlesw5vvkd",
+    "address": "erd1hnp9c2ryy2h70pxmayvuq2c57enf5qrpqjt060h269crczpj6sqs0jdccx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11920,7 +11930,7 @@
     }
   },
   {
-    "address": "erd1qaqtgwe78nan9a5gaj4xl0zl6f6ltg5uu299xhwdqplqnu962rmqmmp3cd",
+    "address": "erd1lx6z9drktq560tcngata42gmuum45422d369fd96j863muexh63qxfa3u3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11930,7 +11940,7 @@
     }
   },
   {
-    "address": "erd15rca7agn80jpyjvdunramql37alzla8h680c40y4nt88ylzgqsrss7jcfq",
+    "address": "erd1exwu88gsxaj8laktgy8z737hju3zpls89cngxxx7ed98pqnljm6ssnmfst",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11940,7 +11950,7 @@
     }
   },
   {
-    "address": "erd1vca5dc458wp297sagyw5st5v5h2z4xk2w3efsdjm58c4wtnv9xwsh5yg0x",
+    "address": "erd1ckkkgj9lhuxleng9sukn3zt7ykfmxjke637rg3ra5ljd3xegj25s4z99cv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11950,7 +11960,7 @@
     }
   },
   {
-    "address": "erd1xntwgcp6cwxh4fjgsph48nt7wz2umk6jc5u8wg9rdtx52tmtvsmq4nzqc5",
+    "address": "erd180my7gh5cq3ttsung95lze5czyyvu83hyt6r7qperezrvqlygdlq49hke2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11960,7 +11970,7 @@
     }
   },
   {
-    "address": "erd1wjmrfeww8032syudnh3dkcdynhd2wj4leatycw58f9fsx06xuzyqa6l262",
+    "address": "erd16czheez2ukd7smfkvew96s0s83g2mw4llpjpl6pj9ayh6jne6dwsgf0ykf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11970,7 +11980,7 @@
     }
   },
   {
-    "address": "erd1wwwnn73rx7407me05zzstrg5aq0k72jpdw24vnxzky999vdhjp6qj8qlfs",
+    "address": "erd1g5gkrxwc2eq2swyru5amf3ssefhn7yumh7guzhsedqecsact6jusdhgls3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11980,7 +11990,7 @@
     }
   },
   {
-    "address": "erd1mu6z2207mrvw6u3l74ua9yzhx7m4403npmjsltd2jzjpthefgxfsdd0p3p",
+    "address": "erd17ue999x59mg5v9lx3nu886nmkvwc74r6dg6l0eyyttrh87kh9lnsnjjm34",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -11990,7 +12000,7 @@
     }
   },
   {
-    "address": "erd1u0d68wd06cxq95g4mvz2lr68p5wuvt3gjl07rhgptvl9a3xecytqnydux7",
+    "address": "erd1zk745ylramjng4h5n29qyx5k3xt6kmfu27eamw8v6w83pnlfe68qre7nss",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12000,7 +12010,7 @@
     }
   },
   {
-    "address": "erd1t3jp9drsjk9hu7mvcmsjy6xn3ncu02fyz7ll8ldt4ezckyk23x2sj2mrtj",
+    "address": "erd1y8z3x5wur9ugtnls4a3ptc3yxnch38qpdnps5fdlyxulnveau87qqxzn7h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12010,7 +12020,7 @@
     }
   },
   {
-    "address": "erd102lzqlffcvcr28lp4d3qsarwl78k28fvzaea6u0seh8hz0atdauszuctjy",
+    "address": "erd1evu6p3fch2ekj4y7ehu0dd0t3hugcsxkkwg9nk4cw9hrmcdrrljszc90pv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12020,7 +12030,7 @@
     }
   },
   {
-    "address": "erd1gwvs69apq7mmhuj9530ajmlqfacqsdqzkwggtjqrje2deyavd5xs5w0d0c",
+    "address": "erd12hpvwhv4tswen8frkdf32rh0lqqj2xelpr4g0cuu3cj8tj7q2g0qr32uar",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12030,7 +12040,7 @@
     }
   },
   {
-    "address": "erd1d6r4ekyufk39pkqgqt7r6uvrjanznq6vce9sgkcy8cresua6q5ms224yv4",
+    "address": "erd1arg5yxqkay3ysk7dt73nww8dxqegtf6l5m67kj6tkysfdqnwj6lqe2n8w7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12040,7 +12050,7 @@
     }
   },
   {
-    "address": "erd1ps4ezn9pq6s7krvnz54cy25rd23x7ksz58rf08rky3e8g4eev9xska82t7",
+    "address": "erd1fd0a7ungyl6y7t6jfj72a5735hyxfyld9gudsf3mpdqdg86h2hkqahtx06",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12050,7 +12060,7 @@
     }
   },
   {
-    "address": "erd1fgtkal0qqm8e4pyfudc0u0ykguake34h3f3qy57gd25tks266jhs9d288l",
+    "address": "erd1h2tna3yvrntclq6ste7k0trm3852mwe9su5qs6wrmpsm0vukuakqw043um",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12060,7 +12070,7 @@
     }
   },
   {
-    "address": "erd1tk3k3ge4fwgzwk44acwcxf9fnxucdnxhsqcujnny0ap5mqkf89uq5atkds",
+    "address": "erd1wgp94349mm54ej6kcun6ecahl726353yy4gvqc3yp29s8zzwtqrq0f7nky",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12070,7 +12080,7 @@
     }
   },
   {
-    "address": "erd1t8ztrcvlz5qjx9zzkfn3m8t6h8f58t872h59ya49egjedgpwwk9qza8hcw",
+    "address": "erd1ecmrjzuwac9cwwytnu9yjxjx9tfsz3t4jl38lqk2y2sxp9syh4qscvn33l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12080,7 +12090,7 @@
     }
   },
   {
-    "address": "erd1yed8gtxdu6wjazajwncnxedmspyfpjgxkg29u0qfzp0laujqc42qlnrf4d",
+    "address": "erd1z4khau8xcaut4va6m2r905kn5ywlspc3jqg2c8l8xuqzy95mufmstej3k0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12090,7 +12100,7 @@
     }
   },
   {
-    "address": "erd19mlj63mz8f5sydmtx2xzt5pqmmpfw49cj042n24eytcsf9fvf6hs0leh7x",
+    "address": "erd185teugfmwm0vphsnd8e48k3htxh9y55rag7gmuw90mq80c2uadhssx3e42",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12100,7 +12110,7 @@
     }
   },
   {
-    "address": "erd14078z4vazqprzqx3m5wj6vkqj9rvgfuhq05uj2ye8xwun60cuxqqn33jd8",
+    "address": "erd1elxkrc0smzvjyacwpzzne33zk8w7udlknwcad7n3525gemw5874ssspqh6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12110,7 +12120,7 @@
     }
   },
   {
-    "address": "erd1k8aql6rttlx20h9uad3xrcaz0e00ztnjr09s9cmkwwutskxhdyyqz882lq",
+    "address": "erd10mtgfdhryq4s433kcjqtx9p3taw6unfeu9xv3zsnxytfydpln66qfxvz7a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12120,7 +12130,7 @@
     }
   },
   {
-    "address": "erd1z3a0qglhjaz6atm5pdcvr73l6utnjulq3hsh8qsygz8j9zuvlxhsjkplk0",
+    "address": "erd1g5trmv0jxaye4tdwj67k4fwlykzrdvhydxwnxy5dmyv2lx4twukqc32yck",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12130,7 +12140,7 @@
     }
   },
   {
-    "address": "erd1gdz5sj4f3d4pw8vzuxt6tmp5n3xh0edv0p8ajac0nsqxqrqd8vfq3569s6",
+    "address": "erd17aelud0a0l5jpwcysevd0t33pdpzjq7znzm625f308neq65y03xss3xahp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12140,7 +12150,7 @@
     }
   },
   {
-    "address": "erd10whd6vq4mpgvwtc6anv6ywryce4adpjqxgr6eze7zgkyrprs56aq0a0f9e",
+    "address": "erd1vun7ygfvst0efum3nzlua3q6kcuw2ph6pfsauca962q76emgp40s6pwpsp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12150,7 +12160,7 @@
     }
   },
   {
-    "address": "erd1v2hwet77l9edqnrjuxuz87dagzjlru8vqvf7uun9cz4mafy38mjq85e6d6",
+    "address": "erd1n7q88ekaacmds8v3a5makhd3nhkljmk5vlnjqj6ey7sq9ceyakwsxfttlr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12160,7 +12170,7 @@
     }
   },
   {
-    "address": "erd1ve8h65ga47h4u8wku07mjaazrv0qfmc4fmq6f4skrn9d62ddwf8sjtket6",
+    "address": "erd1c4jxtwtl7t6dea32tr6jz440pksgvfke5j0lz9awwwwv3mkvdaaq47yjk3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12170,7 +12180,7 @@
     }
   },
   {
-    "address": "erd1ettp8y0frzrpm9lvv3h0gh0j4p3d2nt9d603fex7fwfevnt9nhmsjkpw5t",
+    "address": "erd14g55mdeuhkqzr65zclhghxvymrws6dccndv7dswdv4wlawfasn2qvt74u3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12180,7 +12190,7 @@
     }
   },
   {
-    "address": "erd1p3lantuu8fzajfdthxsns4g3hk70t7t869d4uxvurgm08c0x076s338r3l",
+    "address": "erd1dnj9pyazd2jd7xky7g03qztexuf7h2djmrnmzkl66pw3l8s573ts4ap5s8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12190,7 +12200,7 @@
     }
   },
   {
-    "address": "erd14y7f4wy20u0df8smqez5q59xj3mjshrcrx8d5yvwnwsd7hl9p9pqs2hfcl",
+    "address": "erd16sv4z2276mgagp8skg60awys3n97xzwlzapkn8zzxl97y02txwas5vz3zz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12200,7 +12210,7 @@
     }
   },
   {
-    "address": "erd1nukprpag6fxqwn0zf4d0y37hp2jrzvur9ys2a0m77ev27x62t23qu42tmf",
+    "address": "erd1t9zdqgrkqpsvc85hmtfjxhuzgkvrf7dqhc8uvmh9e40zymkgvatq9uqxam",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12210,7 +12220,7 @@
     }
   },
   {
-    "address": "erd1g7cd87k8zsp6zy7dmz5cvth0pzwuqjk8wux9kgshe69awclm4ndspxe8as",
+    "address": "erd1wwp4kljmh7svfcd2zh8kzxptnv75lk5ssgucu9tmpvf9rv6q6clsfvaeex",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12220,7 +12230,7 @@
     }
   },
   {
-    "address": "erd1g66vud4dkt5r2x6d5rf2dy69myu623mqzhexsm3uckq6a89u25as5dhs20",
+    "address": "erd1dh8dg8dhgxf9rwdnqj69tmsa6ga568l3kcc90g3k5d5526650m5q3huyxv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12230,7 +12240,7 @@
     }
   },
   {
-    "address": "erd1hgl33xgfwqk27zdkcga68ecncxgqaxhsyqcmew75frgz4a2cse4qsdyvxf",
+    "address": "erd1xdz7rhlvaxkuk6le3rkllm3cevw6hgy4a5mag80p9twlx4xzpcmseupaf8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12240,7 +12250,7 @@
     }
   },
   {
-    "address": "erd1m506rermnsagfyt2lusazcgjzdt44hw6rhss9zdf8rdpfnugduqshcafp7",
+    "address": "erd1xc42n7ucmpjlk73dyr7mu0f7r24dr6uhem9yy3nzjsgnqk9g43es7pw3zj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12250,7 +12260,7 @@
     }
   },
   {
-    "address": "erd1r5auv87mvwwyuzdvz0usphk2s0hcvmqnrmxn0u50fqhf25tw8rvqe23jmw",
+    "address": "erd17gcykky9qlv42xklgqs3kldjpl60a9w0fuj505znc36wrq2ujgus63ta9x",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12260,7 +12270,7 @@
     }
   },
   {
-    "address": "erd1779wct28nf7c7ml7dfzsg60l0nrgs6hm8sc4xfp3q8jgr9nwrz9qmz9j77",
+    "address": "erd1xd9khm3rkqga8rk9j8j6vkvfdtvf6uh95t6lun5sxh7qtsrta5lqseg3at",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12270,7 +12280,7 @@
     }
   },
   {
-    "address": "erd1c7uaevlvylyyxvljwzs2ym32405m0jlsyy8g3t0jm8ylvy5syswqkqlaxr",
+    "address": "erd1xagmffh6tvunka4kpxu46cqwz43yesvzg2sgtet9sc35xy70skns778egz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12280,7 +12290,7 @@
     }
   },
   {
-    "address": "erd1u3cuf6cweszr99u3zjrek8ps090a3ex4y0jehys3ma7sd3a5s3qs4atmlq",
+    "address": "erd16ew86z7tvx70pr8metna3ke5jald82ygntedxsvpy3rc7gk2mlrsxld3jx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12290,7 +12300,7 @@
     }
   },
   {
-    "address": "erd1df4s8akcj7wpmhmsq85xp7l7eg9d0wjag2d4yt6cal9l4hft64msexv682",
+    "address": "erd1vmym8ra6ke9x5q26gg5weut0csu95p7rp0tyr0dd5ys50sl0vuhqmrzkn4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12300,7 +12310,7 @@
     }
   },
   {
-    "address": "erd1e6ssrynh5y4n9yagtd57x4elnquh9hagyy4pll6k3wxg9hj67q4s5a6x20",
+    "address": "erd1s50n3qtr4amw39zzmr05l99atc3nvtdqaftjucr9a3ene0t5rqjqr0hl0v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12310,7 +12320,7 @@
     }
   },
   {
-    "address": "erd13w8uj3w63z0gk97shvfrfswcutn4af506h4tljwl660tu7um8klswv3r7x",
+    "address": "erd1qkty93qtc6swdx3mjlsjwfkdgacdz688209fkvlj0nqcv072u2qsgwn4ug",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12320,7 +12330,7 @@
     }
   },
   {
-    "address": "erd1paje6dhx9z0cda9k8pwm9uukl687n4yfcfjgsvnqs5ads4qe43dqha2f5q",
+    "address": "erd1uj5hmu7vxmds9jfyc44l4qsan4cp0lq3f8dafuax5vxlh8rqs2aqdjwspg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12330,7 +12340,7 @@
     }
   },
   {
-    "address": "erd1msqtr99j72e9uj275n36e58a6vnch5ncktrdw5t0m6g06xm7kcvq98hy59",
+    "address": "erd162ed6rc00w83dajx73vlkkqmn9sceckrr08trrtf7vtqsrqvqyws6ht7v7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12340,7 +12350,7 @@
     }
   },
   {
-    "address": "erd1uqc65aawzj8v0yumzeaz37v5k9p23kfgel0t30g2xj8mmrz0rpss9ngs6d",
+    "address": "erd1eurvwx4gywjvk5542x0zkkqx0wq3aqnrm8qgq487mh5v5x9jx2ustejf3y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12350,7 +12360,7 @@
     }
   },
   {
-    "address": "erd1dtn6chg7aawdcyvr0t4whp6xnrqtgucpem95f4qqgxg6zu0jmr8se56yaz",
+    "address": "erd1y6dwz9f4y6jkn2g0wxnaapms2ax4srpwhpr3gsak62cyw36qhwwsustrct",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12360,7 +12370,7 @@
     }
   },
   {
-    "address": "erd1kl9us7uwykrqneyxxfak5aeewnfx9cw3t8sa9s3yzm7gwejan85qvfkxh8",
+    "address": "erd1nzx70ax9xlehq3ta0m77guqawzs5psztaw890s94uccgw5cwkyrs0mk5lj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12370,7 +12380,7 @@
     }
   },
   {
-    "address": "erd140tcek08wftmxey8y0kas5s24mv9y670wgkwzv2d9269c3eekhkqaht65a",
+    "address": "erd1s4dccjvfx6xhjwvhhz8g4jhe9wzjma96cdea6fzg900rzkrdgekswwjjhq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12380,7 +12390,7 @@
     }
   },
   {
-    "address": "erd17jtgphasx0u3ua0zzagsvxq92lyvmmpmmee29ehuqneqmfklcjgqylc48u",
+    "address": "erd18275j7nkjrx2syuce7tqxd5658ge6lmyc8czk39fmxaa68rdqtyqt79ksh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12390,7 +12400,7 @@
     }
   },
   {
-    "address": "erd12gkcxfk3qhp2m5v093827mgk36plm9sp85fp2uv3p68uqrsfnnrqm3n23q",
+    "address": "erd1g3x6d3akqu5jm9ryht2u29f7yfynsh2v2u6qsz2qzdy46zl0rd8s2wpjy2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12400,7 +12410,7 @@
     }
   },
   {
-    "address": "erd1mwkmjjsf4lyxpngj2khlu5j60p64zntrh4xpf9kavh38z9hx7mmqae05yy",
+    "address": "erd1glcdk0cnnmv40z3zmsgs7nxm5j8vjaz3jddsg76mtedcvdq7d8jszr9klh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12410,7 +12420,7 @@
     }
   },
   {
-    "address": "erd1jcp5rjlangvlpjelyk2hsrrc8kcvcsyxfwcjsp625s3vq9kkk9sq8ay9f3",
+    "address": "erd15nx79qtdhe2nzne8fxpheya8ehnxcyr8gxukceq445saldf72uvq2waduw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12420,7 +12430,7 @@
     }
   },
   {
-    "address": "erd1tpqltqac7gglgm5fa8u0924e9a0g83vaqatz06x8eguwyewuf40s5nnv9s",
+    "address": "erd1zcfjpmwdu4qrplr9vjtpx3knlzgr8uluc23qha3ezgzw509tcwvqpp3yr4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12430,7 +12440,7 @@
     }
   },
   {
-    "address": "erd1xnf3r9f7jrqljlvpxkkxv696kjgs0s342j6faefx3yzstszktgdsdqaa7t",
+    "address": "erd13ue5ld4l28uk6dwnj0axzh3lje52ym05tt444jhuuzsav62j2m8q5ylzw2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12440,7 +12450,7 @@
     }
   },
   {
-    "address": "erd1tgn9ydee37r7glun4qpv4yx4srgs9amcyrv4gn0qvpl5wuw3tyjsqeflcl",
+    "address": "erd1r5q6sd6u0289njwqm4g4zv4qkdvaluvum86cpa2hpg8uaehktfwsucjpep",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12450,7 +12460,7 @@
     }
   },
   {
-    "address": "erd15fedvnr9tx6es6nnvjk8kwzzv6qklcdaccsrcymkk4ah38hrcfjs8vn6ql",
+    "address": "erd1wvev6425ehagz8nx5yvhuzu50ammg08l8fvswranllmgf5gmjjqsdq8unk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12460,7 +12470,7 @@
     }
   },
   {
-    "address": "erd1nwmw4n2jnnfhl5m355as32he4d4zvh0wm4lct89mg240s49p8p2qnyduel",
+    "address": "erd1ev6u58hz7s9chmfrvkqyucjmj27hg49yge0xn8xqpqwpn0huu0pq50hmux",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12470,7 +12480,7 @@
     }
   },
   {
-    "address": "erd1y7x7sgl9x4ruvxk58nvjrr93nssaq9n50fdlvnlcc3aeg7qu4n7qndypac",
+    "address": "erd1yea6936u44nplyf3pjh5px8gt8ptzhwatmua6uh9s7et529yetuslqgx6s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12480,7 +12490,7 @@
     }
   },
   {
-    "address": "erd1pfz5enukly2ku2gkjcaacj2x5mm89gg7vuw6p3820xmpegsztxascdjp4u",
+    "address": "erd1237m6skcuvu7580f4cmycaed9pvj3fza28q4duy0ps3llguwmqpqdtym77",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12490,7 +12500,7 @@
     }
   },
   {
-    "address": "erd1wwsvm8kvq5cnu0pyjfs4hq9lj4hgz4jum8d79579ja4qtkpnfhwqakxuvw",
+    "address": "erd12h0cwyfqdg2gj8f32pmjzr50srvp0v54rl6ps8wffy7cyl3rdkss48554l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12500,7 +12510,7 @@
     }
   },
   {
-    "address": "erd14skvzln7fkzyj55us2svpd5jgkm3634th24738hwxlr8twmfx5pqnfwhpg",
+    "address": "erd1wsesr63zy3khd5w7h30fp9sgmy890hfku0rc0977k64k6tpe3rnqe9sj2w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12510,7 +12520,7 @@
     }
   },
   {
-    "address": "erd16e4asehq2ylczlp2253tfwe4q4lsplxyt0j0pdgkllq7cznyf6qs5v50mu",
+    "address": "erd1rhpudvtkqat7gdu8t4taaldjf5hl8vl5lewds7cvywfpux26gpgqd0qzmk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12520,7 +12530,7 @@
     }
   },
   {
-    "address": "erd1vudgwmppjdt5sc4lfgfqmhpj2r3zaf2ztlawzfytaxc02frm7qksgsypy8",
+    "address": "erd1rq55rd86lyxzcel08jplunu0pfvt0ywrqesqpdrj26annzdet4uq2zpkxc",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12530,7 +12540,7 @@
     }
   },
   {
-    "address": "erd1zkl8ry8fljzf3j3xpv42l6f7ayzy2zcvdp0fxufudljdf03czzzsrth5dj",
+    "address": "erd1rpayffd97hxfugwelmdedrjqwxe3yzvfutv705t2h70ftkjneseqxsh82m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12540,7 +12550,7 @@
     }
   },
   {
-    "address": "erd14eg2upm689324wncgs4k29ncvkpn8hkjua97hkev97hkxvjja4rspelwc2",
+    "address": "erd1umv25edy963x4ej7lgqgcl2q4m0pnx7l92rn55cjrp8rl83qntdq6z57d8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12550,7 +12560,7 @@
     }
   },
   {
-    "address": "erd145g704m3yqlwdrdk74qhyr7ajyxep4pq6emuafz9f3t7hpslagyq37usgf",
+    "address": "erd1s709ug0d68sh09g59qeu0yxd654xcm8vlhhv745hzg660mg5jussg4q068",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12560,7 +12570,7 @@
     }
   },
   {
-    "address": "erd12m824y8e7nhl54pytqqp44d4546uj5pld3s33xxcp28707ypjddqev0gn7",
+    "address": "erd1lnxa2wc87szz0wmeqpghvtgd9jzwamvaryxcz58asmmuua7wdznquhffc2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12570,7 +12580,7 @@
     }
   },
   {
-    "address": "erd1j2esyzwy2gp99yf8ej0eeq8a5lygz2cvdjfqprssnntgjlj6lvesk4pf39",
+    "address": "erd1ejafpmr03s2s0pxq02wm6rfqh4us5lyu9mz7xrmczwkrrz3zgh9sgxmhcw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12580,7 +12590,7 @@
     }
   },
   {
-    "address": "erd1zjn7t8hw6yj9fneatqf9lm7seggx0y787pz0ute3nl4srv7gt9lq2e2fr7",
+    "address": "erd1su0crsqdq45pugz0pf2ckfnnwx23hzxm03ruv0uqdyq9c6m3ezkqeetk27",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12590,7 +12600,7 @@
     }
   },
   {
-    "address": "erd1tygt2dz0zar0umr8mq89kvpgkgkt3nt7z29c5l0peyfl9d2qe96s93775u",
+    "address": "erd1uu9ersq0f2d6zwva2yz2r8rf2u20hzsljj430zgj9afd0tr84m0q275egw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12600,7 +12610,7 @@
     }
   },
   {
-    "address": "erd1jqrcg45kuhcyktklqewh9qxzcnfj2649ndtuzhrz96jzl5v3l4vsy5jh5w",
+    "address": "erd1hzujuu034qn2q95976kp2s292d46566am0m4u832s4jv7dhxe3zs2360qe",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12610,7 +12620,7 @@
     }
   },
   {
-    "address": "erd1ge2ppvwcsh5jp9paja7tt7rfn57s5x4s55l87ef92wnnu2hfvmfqwunc5s",
+    "address": "erd1qy8lvf70avs0j9804v85mwjkcgp7ssyy4ccdc34umpggfsanghwqtp4mqa",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12620,7 +12630,7 @@
     }
   },
   {
-    "address": "erd1p2z02rq4aatvxjzvhlz54h3ntfwakay85t8hwwuz3ukdrxe374xqavxmpy",
+    "address": "erd1hq0tfrl4r9xh6jdh436spy7mt2ep0kkg9y9ve980885lec5qtrmquycpgf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12630,7 +12640,7 @@
     }
   },
   {
-    "address": "erd1ztdg2gavce58k6vls02e5kl39qwm0wsz98dy5tue8jdp67pv6ztstl8868",
+    "address": "erd15texv7fwltc0xqlqppuhkvxermnjrp4ujtyx6y3x83uvdexresvqrnqd8a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12640,7 +12650,7 @@
     }
   },
   {
-    "address": "erd1tp425wf0mpde0jx3m2g0wkkcxcm63smsfva4fvt5etcjzg0ay5us469pn6",
+    "address": "erd1h54yexqcjn07dv2ke8vpgfrfucu584v4yulynnl6vyxfl0jxkr2q0h57yp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12650,7 +12660,7 @@
     }
   },
   {
-    "address": "erd1lzte4ls0eten2z8t2g9lzc34709rgrvj7tfgdx3ndah846tuj6rqh27equ",
+    "address": "erd13httcapreu82daqgz02zq2ldwjw2we40wpkz5l9dr5j8un2gsr8sf2wsjf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12660,7 +12670,7 @@
     }
   },
   {
-    "address": "erd1rku8g86e3nzkypuxc4gqwqnsr0dqgewztvv77m0dt3h59ftu9k2qq4ca3z",
+    "address": "erd1hr9v3jnvyqmg6nng86tpld9l4ulh7uu3ztkmwy8utdsemuxh8k8qudyzu5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12670,7 +12680,7 @@
     }
   },
   {
-    "address": "erd12kqnr7fx9a95hu0f69pm4yf2t693cw9c3achdr4jl4s26g6g0w7qfnda3x",
+    "address": "erd17rcjy2yylm5fmc5vde08y5kzcj44c2udqcqusq52lq6w2uc74a7slz24ex",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12680,7 +12690,7 @@
     }
   },
   {
-    "address": "erd105plm3d8qq84dnfg0vurc3p8xk7mc9r6520xeekh2s2u32awlukswru6r3",
+    "address": "erd1zhnurt7np9uy9jpl3trvjhd3ptaxtrdu8egywff7nqcfky0k7maqq6e94h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12690,7 +12700,7 @@
     }
   },
   {
-    "address": "erd1qjnv5rct9l8ewu2ekdyp92wzzldg2rcz426ck9j6mqgahqfetseq66v67h",
+    "address": "erd1uxsjuzq98xhqsf0cg3azly7cgj55l9ztp7la6wm4g92vy7kdp9cq3ltuf6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12700,7 +12710,7 @@
     }
   },
   {
-    "address": "erd1g4f0hglh8jcuhzpdm8j6ca3r8nfm852n5hzp8fallhxmxky8ahessntkp3",
+    "address": "erd1ez3lf0ttmwzk39adn4n2xuhckdltsh3grp9txedwd7ytc26g5dtsdf99t6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12710,7 +12720,7 @@
     }
   },
   {
-    "address": "erd1axcuqq5jrw443tfyarxdcdnu5e0whzphwnr5tdvlckn9ppyrxs9q0xd3xk",
+    "address": "erd190jwr9qc78mhk0xue4aqm3z46rt7jpvrsl4vftcxsktx52lyxx8qe37rpx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12720,7 +12730,7 @@
     }
   },
   {
-    "address": "erd1rstcnzv9xu2r98zjf2xykmuzsq2lda0tflyvp2a6ee4p994sd69q00gxnf",
+    "address": "erd1zznh6gvueasxvx7qqv8pcjeqp6th3c3gvz37tz769zn05l524nwqzzu29t",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12730,7 +12740,7 @@
     }
   },
   {
-    "address": "erd1ktgej7u8zvvzk9hztgsw2ejepgvljgtteslyjj997ff4r33umaxqj0vpey",
+    "address": "erd1puqs70le6fhufakryljdamfvrtwcwtsg2scr3d2jrq98gpxctsgshhz8sm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12740,7 +12750,7 @@
     }
   },
   {
-    "address": "erd1yd4z0xqt9ukhaws9f80ytj84v2fwj9ykvpn4dcxhzy6hj88zua9sajdf5v",
+    "address": "erd1qg8497nxtsxkxeh5p77rme0hl4n0d2u8g9yfu35yzm5y9xwxsrlswpunas",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12750,7 +12760,7 @@
     }
   },
   {
-    "address": "erd1anyxyad4eah56d7pwmujur4jhp4snfexcms0sw7k0ncm8l2mlefqj9sckj",
+    "address": "erd1k2pgdyslt7kh3lz0w5stn0h800jaeje9qplml5cupskjunw360nshkmdl5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12760,7 +12770,7 @@
     }
   },
   {
-    "address": "erd17yd8k3dcjqm2dxnrx22h42kfs4d6qfcrr252unkzk5w3gtwrwnwq730pkc",
+    "address": "erd1yslj5y3qqwp3chxmtql3g2tmldt99cmxdsxuprsklr9x76x2cuys6255ju",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12770,7 +12780,7 @@
     }
   },
   {
-    "address": "erd1868udyrt9z0vlspnru8j0px2dwgnwn67n4y77hz7amk667ez0w0swr3eej",
+    "address": "erd17weysn8wx50yat7cfsytjvdmvlcavlkse9zrkf43nre2x5vacnzqke7pjj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12780,7 +12790,7 @@
     }
   },
   {
-    "address": "erd1tx5gpeecc6p5g59m78g825ywlxmku8ruqcprrt2dgsklcgswrtrq6awanl",
+    "address": "erd1ham90c727jmj8pa5x63gpy8xmy56ftsakxw82wrcqhgk6w3my3gqp50hha",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12790,7 +12800,7 @@
     }
   },
   {
-    "address": "erd15s7fx9a335kgzqku5gc4q9y5vnqtcwaymk04kay3twnyxcymdsjqvvjyfv",
+    "address": "erd18azg4lakm38l66k0c5gj299zuyh3tr545y50wq74xdau43nrmhdq4n2zwd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12800,7 +12810,7 @@
     }
   },
   {
-    "address": "erd1xkw3p82prg2gyuwm7j4zntv8ttxl07dmt25arm07we2u7eqdcz5sf8ul87",
+    "address": "erd1s3wyxf3a0p0f6hpt8a62cgtsdm5q4j5j2gpdyy5f3mvzxka575wsxqywlr",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12810,7 +12820,7 @@
     }
   },
   {
-    "address": "erd1d64dnh7fyys8p0e0qwsh29fv2ac62p9kqvjmvgvfgpmdtg9zhpfqugem4r",
+    "address": "erd12v83mzly3ayrej9kccpch60l49vth4c9ytnj39zdz3uz2qeendnq7kx2u5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12820,7 +12830,7 @@
     }
   },
   {
-    "address": "erd16s47rcr7jw0ztlqfnpdzsav7cndq9hv538k84qv2dwe0ysrs0jmqwklqnx",
+    "address": "erd1mkdjs7ejf3zg7ralk74c20phd43lqs766l8symg7vjem4hk0ftpsvd4ln0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12830,7 +12840,7 @@
     }
   },
   {
-    "address": "erd1tfek7g4hvyaucy9nykm0ma4p5pv0l5t9l2qz2h7qcnu7mcaj6pfq6vsx2y",
+    "address": "erd1p457a4z5rtqlavavjkr33qngv8ftwrhy30du7g039jy733kgv9eqy3d994",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12840,7 +12850,7 @@
     }
   },
   {
-    "address": "erd1x6rwf6ya84hj09un6neqace5k74wp572hr3lsnj4hsfsnnr006wq6fyc6d",
+    "address": "erd1vh967s84hdldutsayjx43klpnakjag9pwdqgdh2jveyhlgg8622sl4np0l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12850,7 +12860,7 @@
     }
   },
   {
-    "address": "erd1mfw7946lv907mecqm8t0zq7vzc2l0eqh07en8kq79fzsmspd3zrqsm2zeg",
+    "address": "erd1h3nlh2r73mrmdjhuale9ntht0v604gujrcsn8d82e9qj8rakt7sst8rrkf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12860,7 +12870,7 @@
     }
   },
   {
-    "address": "erd1tpfjh3k90394dqwwqfe9q7el86uv7n29grx6v9qvfjhre6h2vcjq0k69zf",
+    "address": "erd13zt9fn3uuy8n5ljhjle6qe4m775pkug6y4mw3g3n7hpzklg5y7zqyjlqth",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12870,7 +12880,7 @@
     }
   },
   {
-    "address": "erd19de4036j89j50jre5qjueh9a43atq8urrtdumungujdqsxqy4pesga4gpg",
+    "address": "erd1enueawkhp8a9k6mx078y3xs2g4hd278ewp3ptgg5mx0v46zdy09ql6cl3u",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12880,7 +12890,7 @@
     }
   },
   {
-    "address": "erd1jrm8rzknddzafy3jzeg5dchpwsa6zejxkjv7pj4t0la8p2zr5kuq7yx8ta",
+    "address": "erd1p4yv0jw4jzd96fugkkuyyfx7kw3wszmrm4svw965slerl9dy3fgqffrnjv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12890,7 +12900,7 @@
     }
   },
   {
-    "address": "erd1ym36ju4448r6tk4uk9jqt04ezyf3az6f8nfhhr53afqfsj57fr9sn4t223",
+    "address": "erd1496klwjhv5dugp788j3vhvq0ya0a7gx4ej727kmp572yh5720a2shzqpsg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12900,7 +12910,7 @@
     }
   },
   {
-    "address": "erd1tk0nqzahz3zhc7faht2fsl0jx8jctre7vptxtrsmh9ktnnfvwqgqv55d88",
+    "address": "erd10xny39734my8urcpk89fusru06ddane803du2pula670gsktxp5qaruyuj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12910,7 +12920,7 @@
     }
   },
   {
-    "address": "erd18zn68gchxur9m5enhuekmk77d9zq8kjl6572rss66gdruc2ld37sav8geu",
+    "address": "erd1vltx22tvy5k6mucxv6rmvv9qcetewaxutrv3k4lmp6hxg4saezvsnndee7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12920,7 +12930,7 @@
     }
   },
   {
-    "address": "erd19f7ekdkjcg6jv04esa3ae2gwzwqfl6drr9ma3p8542l90xxl5mzswav82k",
+    "address": "erd1ncygw9rvstgq3hpcv7t5gy24ulwl0st0n2nk3efj0e3n39l4kazqu4wgp2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12930,7 +12940,7 @@
     }
   },
   {
-    "address": "erd152d00rqeaeygsjmctk6ghfzdgx58ve5gfa7q5e8e0ew2nruq900q6jv526",
+    "address": "erd1c84c4dfhthetv9caysk4hmxg7m4mxppvshquq5gsug22qgm267ksa4va29",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12940,7 +12950,7 @@
     }
   },
   {
-    "address": "erd1zvc4glvjtknspgx55pklfqlr6waae40363hj4na9g6qnvevxhv3sylxcnv",
+    "address": "erd1ray6fs7t3xpt6r5peqqqm8qhd40g68dgk6yhgzehsyxsfqrcgyqs59cp6n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12950,7 +12960,7 @@
     }
   },
   {
-    "address": "erd12k9ens3wsu0n38m2lqf9l5yh5fzfey7ghndze5ej4z5045tapvtsvf0t8r",
+    "address": "erd106hlnu3usfqy4jzdr726plf95mx0ugja354u7nhplzve2qj77mpsk9ssna",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12960,7 +12970,7 @@
     }
   },
   {
-    "address": "erd1fmppu7735el8q3v05a802dnhdvfjpzaeqm9suxhzlhamldua3vlsaakf9d",
+    "address": "erd1tun5nwdw2nrge35hca800c46dqy6l7yz6mrmv08047dl6763lngs0mulj7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12970,7 +12980,7 @@
     }
   },
   {
-    "address": "erd135dgysmtgf8v3c3vqvvjccms9mrxh9lkdr330exuklj0xlj6a7tq4m04dy",
+    "address": "erd1nwtqd6qyucdd8avlpqu2s6lrdqdaq6yrqnp0xd0p8jgf94rhz45q0tdx83",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12980,7 +12990,7 @@
     }
   },
   {
-    "address": "erd1ajaa0kfjam4vljlf393tc8gjumkyn90djcyqtprqzeg5t28wpwlsf3vfhm",
+    "address": "erd1wswqyc22pt40h9y845vrr0kgc72pqkwxc7u7jwwsd4ercxyu5fxqeuy2fw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -12990,7 +13000,7 @@
     }
   },
   {
-    "address": "erd127t6ldjsdxrmeyv66vwhuqke3fl9awv6wdrdwkqzrclmf4csy4tq8xqyn5",
+    "address": "erd1gvacpp59gf68vlkhz37zxn5hw44y4777u8c3rts3ufwxxckfjudq3ujwgu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13000,7 +13010,7 @@
     }
   },
   {
-    "address": "erd165f59jy0h6alk7eewalvtdj2fpfftrhe3ex9ry6czpdm8l54flcqtrgvca",
+    "address": "erd1mrklysekf3h82g50vkp3zz74ue5czc4e2gtcz3n6sjn9h8pfnusqccqqat",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13010,7 +13020,7 @@
     }
   },
   {
-    "address": "erd1cgwh0vgajtphjuc5skrwg8qsvv8f08kr9efu5l7hdkwpyycu5nhsmx6x8u",
+    "address": "erd1sswvhespw3adxhd9lc362qx20hrw8dz7s7n6xew5r4qu0pxv8fzsumpwuy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13020,7 +13030,7 @@
     }
   },
   {
-    "address": "erd1hqkeyl9ceej2skpk6snz2s95lgawt6ldedyxwss0205hlvakw5asn9m25f",
+    "address": "erd1u0wt5z8u24z44khy37mdvp7xu6qhayvgj000jf6ckj3jgfjyrf9s3a4heg",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13030,7 +13040,7 @@
     }
   },
   {
-    "address": "erd1eay9f803t9q7pxdexztluupkx38euxjjrd7e3qk0fuscl4vv9pks44setn",
+    "address": "erd1yknsnuecmxmvuxjkpnf0s87nhzujlman5eztprn49nrfysmzjz6qh9gfsk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13040,7 +13050,7 @@
     }
   },
   {
-    "address": "erd1cazs4vyd30m3v4mqcmvjxf8rfc4q4m05tvff9vgm4l4nqddt5ycsezxy36",
+    "address": "erd1ylsn4lfdqmp0eza2nzhcwvkxktw2xcg809qfk7mycuz09spfpv5srq03lu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13050,7 +13060,7 @@
     }
   },
   {
-    "address": "erd1djaxm8dpa6cw32ed4u2drrrrjy8eey00trqs4vmwevsuwgq92xjsh98nvm",
+    "address": "erd1703jq8y32ch5cdzskfk4hy73slf8sfpsq64sgyprslwfdtnze55sj47a6n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13060,7 +13070,7 @@
     }
   },
   {
-    "address": "erd1c7sjr7jekmen5uqrp8kkdw4atrsxlfny5p2fsnjz2fthhlahgwfqkrzcjp",
+    "address": "erd1xwv8fshs3n6m23rv4lnr6fkthwldjmr5agngy264uq0w0t6kur2qxjy8at",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13070,7 +13080,7 @@
     }
   },
   {
-    "address": "erd1v56mfyplpurrw6n5k7622wmdysvsmkdp0xthjrtkjhlum46a7g5qknsm3k",
+    "address": "erd1wghhyt7krgkc33mncqe2q8dt74zhf0a4te8aahuraqv7fwy4x2vshwcjlh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13080,7 +13090,7 @@
     }
   },
   {
-    "address": "erd1zguascyus9umx5nqhqgex5mzdv7dxvd4cw77xulw53xc2697hk2qdkarvw",
+    "address": "erd1jz3l78ylewa3ex29272lmf6w3hzc5s3h2dsrg3zfgcskyf77ddqqnpvd3s",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13090,7 +13100,7 @@
     }
   },
   {
-    "address": "erd1435zmycfg8yynljnha720wafdmk9l9gny4zncy50c5guej3udhcsuh0det",
+    "address": "erd1y3acrc25xu6ft9eucf7pa84hs6qaaucfln7v4zvg4qmru9aw2h0sa6fesj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13100,7 +13110,7 @@
     }
   },
   {
-    "address": "erd1rn6glj8z2f65dtg4ft784rv79a2nx58j480p4p8r5msyagl767jsmymwkc",
+    "address": "erd1g9w5gumd5tyrfl3wqjzva4celgl60c985xher9uh0s5zpl6qaqrq4wcjy5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13110,7 +13120,7 @@
     }
   },
   {
-    "address": "erd18pu0l0fcmjzqczdaa6r78glxqyn4gvsx5vvw5gty6c4s2y0lvjmqlsz0zj",
+    "address": "erd1rhe2yh7f3undmfrl44mtcknjft7k7t6w2r06wj3ssmjquqygdwjq27j238",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13120,7 +13130,7 @@
     }
   },
   {
-    "address": "erd1j35hm397vr6dgnmakr98mexje5y5fzd64slrhwjh59e75ylue4uqsdyw7r",
+    "address": "erd18er4538k0tfmv64gatxdnkfdc6aqaxg0utngw09sq2uru20p4yrqz4c7pw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13130,7 +13140,7 @@
     }
   },
   {
-    "address": "erd18qch6sm89yyhy2yfau2hsjp0rq5a5htynhr5fjh9x4tpcskf687qpuvhjw",
+    "address": "erd13pg57x8em5ru4par2unf5aeylhmw28hmzpmk4zlyrxglay3v5khq0e60zn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13140,7 +13150,7 @@
     }
   },
   {
-    "address": "erd1nk96w33rqhtx4e80u7aw5taekxut0gg265sarenj0mns8qtqtfaqq7dt3a",
+    "address": "erd1ptchvgp7gqy84dkpdpunp6pvj2qw63nz65uj2z3vvmxusrxufvnsm7ksjd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13150,7 +13160,7 @@
     }
   },
   {
-    "address": "erd1622pc7dqufefss6mcq6mc7ama0t0tdv4z4ngcsw75pevftp6fq2qnf5akx",
+    "address": "erd15mks9rumyycnd2er4muz8tcm9ylcd8uylfrp4evwv4x0z7yqq02qt975gv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13160,7 +13170,7 @@
     }
   },
   {
-    "address": "erd1umeltmsmqtf8hhgkz7zd7rqctazkesdx4kpc72dacr4hvdawjklsny3hrx",
+    "address": "erd1xsw6epwh8uhjm9tmuv9drskv78rjtx68dyrgn070340rdwegt56stnpze5",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13170,7 +13180,7 @@
     }
   },
   {
-    "address": "erd1de6f9hc8ee49c9lpx7z73frmz9dmnhju082rwjx7vj3fz3xa9gfq4mgtgp",
+    "address": "erd102l27pvyzzczwjqr24vqer7j3npdc3cf6mgm27g2xy32qgzypgtq7xhupt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13180,7 +13190,7 @@
     }
   },
   {
-    "address": "erd1gxdy3r389dfw9qs2kk5cf32ak9ewaxppmwynkun5x8qlnj5ul89q7r8mkg",
+    "address": "erd1q6m7lsxp6xtxx5v998vvmphrfrw2m9lar26et4jdaydgetce2z3stj5g2n",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13190,7 +13200,7 @@
     }
   },
   {
-    "address": "erd18fwyh6fplr69vjdlzqn2wsh9vff7epkpj8xy8u4lruhghkwnzesq790skl",
+    "address": "erd1mypvst497ln4m8tdsgl99lp6zeavwpdcnhvyxdl6s8t9w5ndzkpq26lu9f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13200,7 +13210,7 @@
     }
   },
   {
-    "address": "erd1ztx8yru8jtlqp9aesl88qwq9j0pzfq78mty3p694rmgqlpjd0myshaglwf",
+    "address": "erd1fq8lq7exyssqgz037z08nheha3m63p56gvkmsauprkresyxttarqnt7ge0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13210,7 +13220,7 @@
     }
   },
   {
-    "address": "erd1ktfczysu44e5n9c3egwkvfjypl5rrxy66qkw9u9qd8qmwchr32gssj9cvs",
+    "address": "erd1p48wkw2amnj6u4k5g8acccwgl24wx83ce424e6s4lh4tqna78kfs2t4nzu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13220,7 +13230,7 @@
     }
   },
   {
-    "address": "erd12dmplt4a7se9c6m7pldcs8v3vcwdudmcxsvkhaq5z75lrnaj7aaq27z6fm",
+    "address": "erd1cxw6ku9q9v0kx6myaxfmnmurrp7uw9f6wrt7zx7l5z67923fvelszxpuxm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13230,7 +13240,7 @@
     }
   },
   {
-    "address": "erd1q49m7u93tq96r62esyp0ss5l8233lrwv8dj8gzsmsfu67ekw86ls86r8tu",
+    "address": "erd1ntnfgpsh2wzfu7sq9xlhme2kplklr9zla6fqedum9zdh22lzh38qr69y6c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13240,7 +13250,7 @@
     }
   },
   {
-    "address": "erd17fvstj82e75p9zt4mmfrfju5g2qpy08jmafc7qd2qv3dj9sleugs2yfpdn",
+    "address": "erd1yxgccd9acv5pm609vdphgvpth7yf9643td0xy77xjnlm7d7q8cpqagfr26",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13250,7 +13260,7 @@
     }
   },
   {
-    "address": "erd1jdgacgn808pygphydf9d57mzx7yqp6ecr8ld4wc5djfpcehd2m7svpxyw8",
+    "address": "erd1exrdlr3e7qvnypuzw35g3w3pe2t7x2ncutmqaax84zmc3j2zkwpquhxzdx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13260,7 +13270,7 @@
     }
   },
   {
-    "address": "erd1rml4www5lhng0lfkm528565nn8qe7rulkuhgpyw4senuesj0p27sz0jk96",
+    "address": "erd1af442axsmn4qcy5mextm4mh2e454wdw5t5lgwvjq6vdejhagt93qy9ekqv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13270,7 +13280,7 @@
     }
   },
   {
-    "address": "erd17gw2uavzad8ckxce2m3cstwd63k8z2p3t4txyhm37tlxl5pq72jq79j2ar",
+    "address": "erd1kvayxhtr33dkpjls3m9lw8nuhaz84ew5ng8v0seh73k66axyjgpsr6uc7v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13280,7 +13290,7 @@
     }
   },
   {
-    "address": "erd143jgdqjg6rnnrgf2t93td2p2dx7xh0uy5gshalf45vav9h573uxqu2ekw7",
+    "address": "erd15xcccjx87fs73jk9pcndy99rnqtpfqs344pxndqjn4c4phrnwwwqhm9n66",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13290,7 +13300,7 @@
     }
   },
   {
-    "address": "erd198jus985ff7nm3h9ekfrhyy3rln5ncy3vdvmx0p43lrlp03rs3msdlpsj5",
+    "address": "erd1krk34s35wajlwgtz7zpmqp7j7kfj3t2trxtyxemt8erfrrg0kkzqeu3r7g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13300,7 +13310,7 @@
     }
   },
   {
-    "address": "erd14gyz93s2wjs2eh0x7fdq7razsh6hvtnvn9za06qc2nc7dx2z6kws3exaqg",
+    "address": "erd1x5edfw59jgu96ad2gp624kwxw7avcljvlq4y7kw7fqn89p2k9jnqfdwyrm",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13310,7 +13320,7 @@
     }
   },
   {
-    "address": "erd1husrjxzdsyv377e0q0wjar4ljpvvv83z3k0sm82z0g9hsg3jqhhswy9a5q",
+    "address": "erd1ky4rk9p3nm92epd2n9a2zr02lypfljnanheyd38mf9uf8crkpgeqttt8cn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13320,7 +13330,7 @@
     }
   },
   {
-    "address": "erd1f2c8fg20edv6ay2uqldu9cg3hxr4k7jv302dky4rx53em5e4jfns92egd6",
+    "address": "erd1yetgvdwvjhp3l4zkgajq3pkrhgrqdr88x7378e3azdp2d7u6e0rs4axf0g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13330,7 +13340,7 @@
     }
   },
   {
-    "address": "erd1cx9e29nwgzjz6klyzller442zlehd53yuxlqssz2rr3gzurxjynscrjlqe",
+    "address": "erd1e5m59jrttjppn6w39vrm3ectvkkyusd6wq3kxjknhhma7vlcxppssa40ak",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13340,7 +13350,7 @@
     }
   },
   {
-    "address": "erd1vpvdxrggnmtps8g5rq4nawpvwx4t60x04td63xl6k6xr7vvh2peqwk3jw6",
+    "address": "erd1x8x2urfyxls6rvpslk5l25s9gcv56glpqxc3kgpa79wn4hu5qz9slgcntv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13350,7 +13360,7 @@
     }
   },
   {
-    "address": "erd1pzc6w9c00lt2er6dr6202e9xtw97q0q9utra9scxh8r97ykh4gaswcrde9",
+    "address": "erd1hnjdf8n99v49vgfe0fvy7dutvjjumy62l3mvze7qlw8mrr3jkq6s5rzuzj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13360,7 +13370,7 @@
     }
   },
   {
-    "address": "erd17k4jm3khujhw9c52levd57md4630xqy6r80wtnxu56s8hr9effeqrlv03a",
+    "address": "erd1jv46le6e5qkufzxy262q064x6thzauja0lzu9u0nwxj0c47yte4sgpxzcs",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13370,7 +13380,7 @@
     }
   },
   {
-    "address": "erd16rwh7kqa88tpfjr9hukdrw9d3up0n68fz9v4rz8qkqa7jfehdmuscx5ar6",
+    "address": "erd1pc8jeus9z9crk6dtz3rv92pfdvvmt0l6nkt80funl5c2ad6a95aqj80w9w",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13380,7 +13390,7 @@
     }
   },
   {
-    "address": "erd1gn9wse2qtf7ravpkyxdg80l0rdv555uyc9sja087rzzrzgaus0tqagsj4p",
+    "address": "erd1h7v4j8gl4jdvsrs5a6hc3rureadc2cwf7zeq459ecjqkr3qkevvqcysu6m",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13390,7 +13400,7 @@
     }
   },
   {
-    "address": "erd1mv9pas5gegntj6wnyex7mv6wpnq8l5ynu86cxmch3p59hgk3yu2qymw4yz",
+    "address": "erd16e7xemc8pvj5lazdjcml74peu8a2pdtwnjvsxaqjrfhznjaw53aqegxlq3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13400,7 +13410,7 @@
     }
   },
   {
-    "address": "erd130z8kzl8kassnghcwz4y4xk4eel42h9nqewy38ljzc9wyk0fwa9sy7wren",
+    "address": "erd133nan4lzwk4rhxfs53gnr3pacn3g8vycmdsc855ypnd3f2vzxq5swn8m3q",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13410,7 +13420,7 @@
     }
   },
   {
-    "address": "erd1x2avwspm8ekl84n268z8fp52t24rxjphwgn5r6989xn499hzvclsdep5mj",
+    "address": "erd1vyt8fjkcran7h452095kqx8s9yf7tjfwtu7xfyunemduz0ntghesvwdkpe",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13420,7 +13430,7 @@
     }
   },
   {
-    "address": "erd1el3y9puf5zwwa7zzeuwxxl3xal4ghqvalq2t2k49l88d0v5tvqsqm2dm6q",
+    "address": "erd1yvgyx0l8qeykdkf733tzwrnvsyxwwcq0tgzs5scjld97rxv72d8sckuvcy",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13430,7 +13440,7 @@
     }
   },
   {
-    "address": "erd1jywrnnwjf6w7vywa0p08hldsy5l2a2ln03at4sa90us325f8at4s4lyz3w",
+    "address": "erd1ntcrg6wjp2xsahn0aply9xp4d2kghkumdjk022d7w0zzzcq0dhrqzajf5g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13440,7 +13450,7 @@
     }
   },
   {
-    "address": "erd1lakwm8pfhsny390x9p82j7p2rrqcxhmfgwasc3jp44n8v500rreqya3nt0",
+    "address": "erd19zvv2vef0szdvss8dmwu23ayfsrj7hy40mdslzhy56mrkde9c6nsawt0qw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13450,7 +13460,7 @@
     }
   },
   {
-    "address": "erd130p3pgzzl0653ygn0ts62a65836qkc58rq5nmsq2pkn3rl5v5afs4l72e7",
+    "address": "erd1xwt35jhqecqc3nqw9jd6nwf5qavf2efjyl5mm25qf8xy2z3thyes2zn7lu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13460,7 +13470,7 @@
     }
   },
   {
-    "address": "erd1zffn26yzn4lm4r0csu3yqmv9gre3hqk4s83vk8jmnl6wv5hz6fpsxaz8q9",
+    "address": "erd1m8trsd6wrshhmf9kv6vulwqx0eu9cstl9ak8g4spzw7ue484upcsl0nz2g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13470,7 +13480,7 @@
     }
   },
   {
-    "address": "erd1gcazvar4kc5xx2st667ylszspxznrmm4dev8warfm3l95md3vd6sz85xsd",
+    "address": "erd19a4w47dhd5rs8zajz3v33z6hvdd24y07edqw5g0nr8wt09pzkhdsdsg3sl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13480,7 +13490,7 @@
     }
   },
   {
-    "address": "erd15v0f0rcw2s6v9z76gk6mw70v35pyhvdd02dk8jf645em33ncmwmqwmnj6m",
+    "address": "erd1frl9usxv47ptjdgueu4vmq877jtv7py82srtse3eqs95lfnnvv3qke5nh3",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13490,7 +13500,7 @@
     }
   },
   {
-    "address": "erd1ucj765c8ld29v8glrdc2w64l2kr9tfvv98j4rlc2wz4j6a2c3qgqdhtekm",
+    "address": "erd1lgth0ysk6yes3wc290nu5hqmfdd5n95ngdwur60p7l7czf4hxnjsf2yhwp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13500,7 +13510,7 @@
     }
   },
   {
-    "address": "erd1g3vnpmkfh72nk9v48c8zqjkjhsg8mpy6a4ke7rxyxug8y0umrfas9y5409",
+    "address": "erd1ghrjnmwcglppyfjldzzp4mm3uk4wzayj9xc29wus0p0npgg2d49s5d5k0p",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13510,7 +13520,7 @@
     }
   },
   {
-    "address": "erd1rl2rynq3gzwzunlgcq8r3am0vh8e0fr0s9ekjas8u0ct5kpsgd6qzudlje",
+    "address": "erd1tu8dy0xuvqk08c67z92nmuapu4daajn0spjd82ksh3dr97rs5d0s9xvfca",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13520,7 +13530,7 @@
     }
   },
   {
-    "address": "erd1395anrhx8utmuv3g4477kj22l3ecnrpdmlesxdk57l4956uvt5as2mrvu3",
+    "address": "erd1adrvgzh27tfxv6p0n45wzq0uc7kn5ptyqaagmfxfl44fh7muh24qs5s4ws",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13530,7 +13540,7 @@
     }
   },
   {
-    "address": "erd1et5t2s9p7hztg63m86ef5hjl47s066dhlkuuxp5h625pf2s9aclqg8dseg",
+    "address": "erd1kx7xcx52xfpdqaamplzu66g0syjygn6zvjr43nxy2a8swu99m0cq5kc44z",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13540,7 +13550,7 @@
     }
   },
   {
-    "address": "erd1wh75306mwwnl3sxgqsqstsk47c5u7dthfqrjn8eqxp9wnsz2wp0qyzlls2",
+    "address": "erd1pcz9kxtf8dltaynkqhkjqsmvll9l4n2tpr3vdhz8z44wycujx6jqp2dgua",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13550,7 +13560,7 @@
     }
   },
   {
-    "address": "erd1phn68ruk35cxnzur5n2tgnqqqzq8ty9q7thurw4ev0w2et8fkj6szjdkg6",
+    "address": "erd16q4na0n2ls0td49ygn2l9gmlxh04fmq4pc6wsqarcwce2mu66qwqflsnyf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13560,7 +13570,7 @@
     }
   },
   {
-    "address": "erd1akntdfgkenupl59hznhftrxpn0vm4804njvj0jhz3zq3aszvhqus8uq3vj",
+    "address": "erd1f4nhg2dg6f5f28gjpcucw64eeypw2uuu06guj654vmu2ye4usl7qzv2mkf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13570,7 +13580,7 @@
     }
   },
   {
-    "address": "erd1uhfq0sdynp3wr7fk5mvgxq4pkee434ag63vyv72x0jer30gw68rs4zzcge",
+    "address": "erd1gjqqxr59pem45xkmfy20uhkjw4u4et4lcvayzd7rxkefcm92p3xqeevks2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13580,7 +13590,7 @@
     }
   },
   {
-    "address": "erd185ctu3wcefgs2zq0acdle6md96ulchc4fqtv2y44pz840w0h0hlqcxfzdt",
+    "address": "erd1mxddfcqdr08202h7v8swnp928vhmyrjtef7a2eyvx07kn8wje7psqcfuqu",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13590,7 +13600,7 @@
     }
   },
   {
-    "address": "erd1m5rkmtkg4ruj4lmvf92yn352z0fuextxf85lt82ll243hx8k06pqfk46j6",
+    "address": "erd1fw9ggj7czdcqd6c203xlnvjv9jcrhr2gjjaxy4rssqvaa9lcp70qa4nfeh",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13600,7 +13610,7 @@
     }
   },
   {
-    "address": "erd1d8uxjqeu8vcj76d0dtpjnh484mwulphs6jk4tt9urcy5c5ds84fsweggrd",
+    "address": "erd1g3m37lw6u8nqxqaa7n9y42cgnmwgpjckz6xjnaf00uuwez0q5xmqwwjn77",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13610,7 +13620,7 @@
     }
   },
   {
-    "address": "erd1mjq4uhyz4pwuzxasm5x3uqzr66ehxcrz6kefjer6h27994xncc7qhgrct2",
+    "address": "erd1m4vw20l6fmxnutp57fgck0czv272aghye0hzl2ksqdnn03ce0tvq56jwtz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13620,7 +13630,7 @@
     }
   },
   {
-    "address": "erd12f5g7rrk740rj0l6gav688607ze7wu3pfg66l880ypttha5slc9q58hs60",
+    "address": "erd13mmu925dvxwuyfvl8y48ag4wnxu2e4hxgr0kc3rf3es45ftw4wvsgjgg3y",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13630,7 +13640,7 @@
     }
   },
   {
-    "address": "erd1v4f7ncp48a72yqgmrvkd46vyl3jv0yp8ayq4dmm8wfv69hjy3swswv2wjf",
+    "address": "erd1hnu0n0s26fw8wgq2h0jqgxg2plula0wvdyxnnc4x2ta7ksvg9a0sftclq9",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13640,7 +13650,7 @@
     }
   },
   {
-    "address": "erd15u2ajw3pvmj92v2g3e4nrd4r09hys0d78428qzw6jsvaz32qlz5qdwwr0c",
+    "address": "erd1cfev2e3yplt2q4u4nurmrhmeercjp22zcrhhhmkde0wg6lvcdwzqxea45r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13650,7 +13660,7 @@
     }
   },
   {
-    "address": "erd1anj5xz8nk8kym4wkwckvfw7z0yhzmc3d93z26vwqqa5umtcaj0aqgv2slg",
+    "address": "erd1t57y6mrnffhxqgrc8c44074ymuajuz9gafj9enc9qe023r7szlrq07wgxd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13660,7 +13670,7 @@
     }
   },
   {
-    "address": "erd1ugqn3xjrveld5ghk9n724q2uuek9255ccn0l0hefsxp5gfkkv5ksnu7ykc",
+    "address": "erd1s8uhdmsywls2vkpecexaqm0ssjkjdlumnqrlvm4ntjqr7ysuqlrskfeh5h",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13670,7 +13680,7 @@
     }
   },
   {
-    "address": "erd166zlv9575hq3ghla7qrtfcvdza6rdc87aq6x3e8skudfytcdw9xq7vd20e",
+    "address": "erd1y4qjel3um3lw4a8ay94jzz9k65yt0ytn9pmwujvwe0vsnna9eamsjngj6r",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13680,7 +13690,7 @@
     }
   },
   {
-    "address": "erd12w93rl4qyy86gfm24eu73gtvc29v0ts4ump4yayu4nmecy7uufkqnsu7u2",
+    "address": "erd12hqyrkpzdt97f2253tzjhhxlgndc66uw8kam42k5cgqeqrx9swxqeazrrp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13690,7 +13700,7 @@
     }
   },
   {
-    "address": "erd1gnfz4tuatyfef5wxjx52x3s9nf377pqkz8cwqs45dpskxz5406qshcqkuq",
+    "address": "erd1lpetclntem5e4qfw9cn5d72x5gqpwfsyyzu58vekcrxxzna62zwswvpdw0",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13700,7 +13710,7 @@
     }
   },
   {
-    "address": "erd1aymdqg9884wyl5z7y9vmcn62wa7jq2a62dh540ar0c9th7qkz88sj7tmlv",
+    "address": "erd1wyz4w5qsgce40wrj4x8m3zl3ky33ugc3zp76gw8ne5pmdspkn35q7llmk6",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13710,7 +13720,7 @@
     }
   },
   {
-    "address": "erd1nse804cen4c7y329r6djjhh83gnt6d4ywverhvka6fhc0mjcp9gq8nuhp4",
+    "address": "erd10k6hcsr6cfqc8rwgarn7sv9jch0nxjre5qdal488lyend6534dystvsrnp",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13720,7 +13730,7 @@
     }
   },
   {
-    "address": "erd1gdt4ynts6quvuz3w6qkaavt7gp06haeztp77pwjznyjwm04uj85qc93mc4",
+    "address": "erd1s3depfegcu9au4lhawq2eq5sd45u89hhhak8u7dchnenjnz2klcqrmuy03",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13730,7 +13740,7 @@
     }
   },
   {
-    "address": "erd1auznejvt4d6z8w9ecpfqwj9pa6hk80stcnlgjdxtlwsqz6vft2tqfwacx2",
+    "address": "erd1yk0rgsjd5qna2hn5x3g4uwge4qhk7mq4g4xrtl6gnca5ykx6gq8st9khuf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13740,7 +13750,7 @@
     }
   },
   {
-    "address": "erd1ncw7p2rugk5pjwvsc6nyae03ky82dg4263wy84uglmh4sxa8esyszvf409",
+    "address": "erd1aelr4jwgauzv8v0fulpy6nnvv366ts8kuvla0nvn5dfhgazu60ssj67tm4",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13750,7 +13760,7 @@
     }
   },
   {
-    "address": "erd1qzpcuv6rhve8nyrnjc86zwwxg9lztt9e7nd2h5zhy4m0e90vsaeslv37j9",
+    "address": "erd1ycwcx6zrntmcdprlp6quxc9a20x47qymuvw3mzqef674u30p8v5q93w9cq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13760,7 +13770,7 @@
     }
   },
   {
-    "address": "erd1puqcyumlqcsfx8h9f3hjuzrhtzjwl3aa2y5aghpkk5zrmw4u0pcq9j4zjv",
+    "address": "erd1a9j0zaqg5cs2aw2nmym4zuu0lr47d7dq4lmc9alt0h2x3mp0h9kqglnau2",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13770,7 +13780,7 @@
     }
   },
   {
-    "address": "erd1x6dcq4cgewwkwkg0c2lxyg7ek8aj2jl9gmqau3xzx4kp4lfgg7zswrcdyj",
+    "address": "erd17rrkckhvjxh054unqge37gkuf3990nud78ssp8y4x34h3jgp5xzqvdhs9g",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13780,7 +13790,7 @@
     }
   },
   {
-    "address": "erd1fmnhjsd6c3rgnxpa4929s3qnglu2q3sp3tqhr762e3wgwnhldrkq7cm32t",
+    "address": "erd1fx7qdmfwwsa9ya49gns5xh8t65080v950n0m09k3urjvjj5x0kksnh32ez",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13790,7 +13800,7 @@
     }
   },
   {
-    "address": "erd169rn2jyzgwv2l80v904yazhng4ym00lja7cthcvhugk255t7n3uss0y04x",
+    "address": "erd1anl46zuqthtrgkfhk80kad7uxcgc4rvd0ykjctfl2pwuh9gtzmyql48exf",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13800,7 +13810,7 @@
     }
   },
   {
-    "address": "erd1sksjt8cz38umjqu8rfs7yjyyvytfwk70jl90f2g9ydvysp2sl37s55l8u6",
+    "address": "erd1aqh853wrcw778n8rdx52jnqws9vrwp4wxgsyc4hg968dl5dzk08qvv4chj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13810,7 +13820,7 @@
     }
   },
   {
-    "address": "erd1neulvu5s535tc9rxvdfndge2ju2jwcn8njjkfhh5tpqpdv6yke2s9du3lg",
+    "address": "erd1kfhh68fx6wukckhswufsfu84ts6cmxdaj7du8h6j3tcyrl9hyd0q8xtjhz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13820,7 +13830,7 @@
     }
   },
   {
-    "address": "erd1799d4fyvqayxt234n6ksw7qrvfs80p8g75v29fkl7wng6666882suwc05p",
+    "address": "erd1kpxmme6l9ja7fw6hdl5kqjydjvnwuzatst2czpn85a03jvt4y59q8k6etz",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13830,7 +13840,7 @@
     }
   },
   {
-    "address": "erd18uxzy5f8gvqntuwgp7w74jk9huyjkgupwh6u9uyf7yz8wq9jpdpssx5rvn",
+    "address": "erd1gyvgyv6zqn5mfr7ppq3z8ahkvflln8ahq5lrpfvjm9qpkpqncuss8drgk8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13840,7 +13850,7 @@
     }
   },
   {
-    "address": "erd15spt20za2nrwgu6xln2r24grpxewh9xyqg2jwcgvt7hpw7ajq8fqd89aca",
+    "address": "erd1705lm8fcevtz7n6565wrn2jnzzv59rte3th58l7d3wrnh9dtmnkss38sna",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13850,7 +13860,7 @@
     }
   },
   {
-    "address": "erd1ydpus6dl5ysderuxej34rlndmwfw7h5m8u6xaatswlnr225z9wrqjdm5v2",
+    "address": "erd1e2mux9kf7qdqmfsdvy60eh88ldkck2qt703cn0adkrvrvtd4ykuqsdvf2v",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13860,7 +13870,7 @@
     }
   },
   {
-    "address": "erd1nhy7lv6hahz7tdu4ufsh7s7ctl666l84z05j6gkdjm8jqchddudsag34fr",
+    "address": "erd1cfd7mlxze79c60t66qdrdg5yvuwlv8kycxzxyxesmdmvg0dyjyxs2nw06f",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13870,7 +13880,7 @@
     }
   },
   {
-    "address": "erd18a29j456wnjnpasetj3nknedfevnje07s26lxzp8x9m8te39vr5qtq3lqk",
+    "address": "erd13cyulpp34r6wdh4ewscdwlsgsu4hll6c7ms6fdsm2j80awmxp4xq2du9ss",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13880,7 +13890,7 @@
     }
   },
   {
-    "address": "erd1c4gppx8hql4c0du8ejgl075me58fg2s4nkwr7y2ejuddgt83aezq5h5e07",
+    "address": "erd1tqsgwepw9qx7svy5r85w7a8fh6l9psvd80zdxhylkjq3mz45c8qqa9kh3l",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13890,7 +13900,7 @@
     }
   },
   {
-    "address": "erd15mtk05zd6qvy7nes3fu6jdsktrlkzk7dawejdx2wx5pyfwyvyzcqnc7eyk",
+    "address": "erd1myzfpfz0j3lnjstceq34dkysry2hp3t2ulcl3c4tst5hsuw4qwgq0rsjmj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13900,7 +13910,7 @@
     }
   },
   {
-    "address": "erd1sq6wv87g5x83vwjqatsn9d46lhpu5epk65r4d5e6ua6e3n56fwmq8tx5ak",
+    "address": "erd1t73lajq4m3ym6k7kd4ytycz3d9wqflmh84jt5ceyf4lffcsa0rqsyz8czd",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13910,7 +13920,7 @@
     }
   },
   {
-    "address": "erd18v3g4vnvyxjv9x477qtedfhlrtn97nt3dp0j7zxps0uumgec5fzs5er2de",
+    "address": "erd1ckdnag85ghhr8k3rpa0u8k5xa29a5lv7m4ejrsv4urj7psar06rsturguw",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13920,7 +13930,7 @@
     }
   },
   {
-    "address": "erd1uhyquq24wnn4c7tynvr45zdarc6j29en33mz8ag3ur36ksewzu3s5jd25w",
+    "address": "erd1rx2awvu3e0vmrmh0et27ndvthwge7nrze7mq4y9tctxnzs3kp86qxtnms8",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13930,7 +13940,7 @@
     }
   },
   {
-    "address": "erd1ymhyy3f85y4fhwycv30t7qawaedk7y6epd7gp9y2y932gpwwthzq7ug7yc",
+    "address": "erd1kyexce3mkvr6keyu5a8qge35s54w0dexrun4ycxaxrfw64kap2pqy9j2ke",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13940,7 +13950,7 @@
     }
   },
   {
-    "address": "erd125l03vukcfpdxzeg93gcp7e3zx00t86evgfnrvw5ls8ax60z3ynql76mag",
+    "address": "erd1yedjz6tpv53h4st7vetskvmvljrlrntu8md6pgl0tkys2xnkpwnsu5hvvv",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13950,7 +13960,7 @@
     }
   },
   {
-    "address": "erd1q6078d2qyc5397x6f9hd6v55guq5djja9tf8gck7wan25t7fku9qsdjfyl",
+    "address": "erd1vsvx60udfl8hs47fksx6zznavs32t38cj7jywy44enj6gvcs5xxq0jhnnt",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13960,7 +13970,7 @@
     }
   },
   {
-    "address": "erd10c4ayg43ys8zf55z2574txxwpc6fpu3awj5j6rs0n6d924acrf7q2rkaua",
+    "address": "erd1kwr44jx4lev6cshayzm5wfzn8ggzz07fle5szaz8w9paal4x2rcsy8rs4a",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13970,7 +13980,7 @@
     }
   },
   {
-    "address": "erd1jka4f4kp06n3q32yrec0t6gx75ugtmzjv4hx30t9q9zwjyc48y6qnjekxe",
+    "address": "erd1sl4glpwmdyljymx52kza67e8m79yhm0spardy663n0kgujkt4rhs2nyluk",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13980,7 +13990,7 @@
     }
   },
   {
-    "address": "erd1fs2gzgc9v3q4apyd5jkyxg9ne90a2lqd79zmf4mx58ksnfe5kjjqtcxy3l",
+    "address": "erd1mkxsdu3e6nscrnfgzu8ak3rzwav4mcwr367h06ed3z0hp9x6q96qcl3t4c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -13990,7 +14000,7 @@
     }
   },
   {
-    "address": "erd1ktcl93jud0l87ndt44c5yxphvfs9h3hxmvpjxghy4pjvlwu0lw4s495ezz",
+    "address": "erd1xue7sydwc6dmvuwh3rr82620a9c3prquj7faffgx9xcfa25dcx7stapyw7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14000,7 +14010,7 @@
     }
   },
   {
-    "address": "erd1fuzx4naqu5vaut2nwhuq6w5tac8vzl0eefnzp37my33xvnd2julsrxs3sa",
+    "address": "erd1xwp4sa8z4ke5dqtfq56tpzlqs3awvjh9lhhyf6vemvdz5qm2cthqqamf5c",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14010,7 +14020,7 @@
     }
   },
   {
-    "address": "erd1vs55r6ne5leg5ucjyn88s3cylpnlsuxqxec4hmnmf43pr3neyu0q4h4jn5",
+    "address": "erd1qcj26pygl7snusqzrj50nvtt554ltql2dggq2kg43rnvfm2jqf6sxvnmq7",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14020,7 +14030,7 @@
     }
   },
   {
-    "address": "erd12m5d266kx7wtnscy0exy6cwnghmp7myfcj3efkra53aw7e5hvyxs3ehd32",
+    "address": "erd105th6ge5u6xtg763dld4sf5h5ggwhy6s08z9raukh8rchgqjgrnquyxczn",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14030,7 +14040,7 @@
     }
   },
   {
-    "address": "erd1cz82gpu5uujhdvrq6x60wr4xz0m3ppuk7umxnnh5epnpj855sfcqe20v89",
+    "address": "erd1v0zs8a4k8utkx7vre6229stkr9ul9k8vz5geg6vmc0rsus4hqngsduqdap",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14040,7 +14050,7 @@
     }
   },
   {
-    "address": "erd1pf538cd3ryy5ghp6syxypcxslyx4frph2d72xgwzfp6ke4w965xswc3jrc",
+    "address": "erd1uz887zhn4v5699scqptzsxgujla4frr4p7c4krex2k0w3xm3v7rqmk6pzj",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14050,7 +14060,7 @@
     }
   },
   {
-    "address": "erd1k89d79lrwlfq9nr2vk62v3ay29l29vdvljmgrj8t2m909lhly99qftj4jf",
+    "address": "erd1d9erkh2vr5y45av99wjdq0qzkqc96ww5a3jh4tw5ahdltjytkhys2j055j",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14060,7 +14070,7 @@
     }
   },
   {
-    "address": "erd1srn5q2c4atg9235ma6nmwzdzsr7peu9tdf6nxyg75pqejll3wmrsfns2lk",
+    "address": "erd1hlhujphjme6dlh3hl24mampz9akf0efrc9kcard05z3t8r4dm3lqthp6kx",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14070,7 +14080,7 @@
     }
   },
   {
-    "address": "erd16qug5uudpy8uadqyxfswszztynghgx94drwnhv4swcdh5uxcn5vq7yhpl8",
+    "address": "erd179czzwy6ftfqt6agdv6etea577mxc9fkc5kgs2yxxvhmy0q4qteqxxstxl",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14080,7 +14090,7 @@
     }
   },
   {
-    "address": "erd1h43tyqsqqy8ldd74608vsl2phqrxc4q4y3zsuyh6wkn93uy23les335guk",
+    "address": "erd1snyj0rna3wefstq3fa8lnmr2dz2yw6enejue02u9awjwt8k4psls2xjpvq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14090,7 +14100,7 @@
     }
   },
   {
-    "address": "erd1ad7ng4r42v69t44me0jtt6sueuxp7cs9h0ymr57qzsrurkdh5xksnhvm7n",
+    "address": "erd1zl2epqg8sltwg8gxf3vlpr4h5k9l3uwtaqksj7sxxmlxj3qgwzkqhtqw44",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14100,7 +14110,7 @@
     }
   },
   {
-    "address": "erd1k3zfupqgtac60t0sgn0g9gjnudddq205h4fmgava8vpuhqgxe0qqpy3r5d",
+    "address": "erd1tf89tyrlxcptgwkjy35vn08eqh8az2ee3jay2xg9xlcaa3me5cjqhvefaq",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14110,7 +14120,7 @@
     }
   },
   {
-    "address": "erd1z4l97gsjwfa5scssstu752a3dqhm525l7uqjjmxe35sc2s532uds25gwpm",
+    "address": "erd1szn5ur7yv8mvywst39hgwjr7dtsaefyky3pqdze77tzx22t99yjs774z28",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",
@@ -14120,7 +14130,7 @@
     }
   },
   {
-    "address": "erd1n9x75s9ue7q8vapfz42uxgy3whuztspqsj8g9zyg57jwpapf4wjsydnzvm",
+    "address": "erd1ugs94py7drj6398vuxgstkqn0pnz004yk6n9kpypgrd72axrsuks2yeqav",
     "supply": "3576120556414219474497",
     "balance": "0",
     "stakingvalue": "0",

--- a/nodesSetup.json
+++ b/nodesSetup.json
@@ -1,5 +1,5 @@
 {
-  "startTime": 1610992800,
+  "startTime": 1611907200,
   "roundDuration": 6000,
   "consensusGroupSize": 63,
   "minNodesPerShard": 400,

--- a/systemSmartContractsConfig.toml
+++ b/systemSmartContractsConfig.toml
@@ -6,7 +6,7 @@
     MinStepValue = "100000000000000000000"
     StakeEnableEpoch = 0
     StakingV2Epoch = 1000000
-    DoubleKeyProtectionEnableEpoch = 4
+    DoubleKeyProtectionEnableEpoch = 1
     NumRoundsWithoutBleed = 100
     MaximumPercentageToBleed = 0.5
     BleedPercentagePerRound = 0.00001


### PR DESCRIPTION
- release T1.1.26.1

Binary: v1.1.26, genesis time 2021.01.29 08:00 UTC, mainnet activation flags set to 0 & 1. Regenerated genesis.json to include pre-minted addresses. 