### PR TITLE
Release T1.3.36.0-static-trie-db

### DIFF
--- a/binaryVersion
+++ b/binaryVersion
@@ -1,1 +1,1 @@
-tags/v1.3.36
+tags/v1.3.36-static-trie-db

--- a/config.toml
+++ b/config.toml
@@ -669,6 +669,7 @@
 [StateTriesConfig]
     CheckpointRoundsModulus = 100
     CheckpointsEnabled = false
+    SnapshotsEnabled = true
     AccountsStatePruningEnabled = true
     PeerStatePruningEnabled = true
     MaxStateTrieLevelInMemory = 5


### PR DESCRIPTION
- release T1.3.36.0-static-trie-db